### PR TITLE
Newline characters replaced by line breaks

### DIFF
--- a/ModuleDescriptionParser/ModuleDescriptionParser.cxx
+++ b/ModuleDescriptionParser/ModuleDescriptionParser.cxx
@@ -1860,7 +1860,7 @@ endElement(void *userData, const char *element)
     {
     std::string temp = ps->LastData[ps->Depth];
     replaceSubWithSub(temp, "\"", "'");
-    //replaceSubWithSub(temp, "\n", " ");
+    replaceSubWithSub(temp, "\n", "\\n");
     trimLeadingAndTrailing(temp);
     if (!group && !parameter)
       {


### PR DESCRIPTION
QStrings are used for Help and Acknowledgement frame on Slicer module
panel. Newline characters are not respected by QString. They need to be
line breaks.
Fixes issue #9 on the SlicerExecutionModel issue tracker.
Fixes issue 2781 on Slicer bug tracker.
