### PR TITLE
Fix wrong file inclusion when using SVN 1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ include(GenerateSlicerExecutionModelConfig.cmake)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/UseSlicerExecutionModel.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/UseSlicerExecutionModel.cmake COPYONLY)
 
-file(GLOB allscripts "CMake/*")
+file(GLOB allscripts "CMake/*.cmake" "CMake/*.cxx" "CMake/*.in")
 foreach(SCRIPT  ${allscripts})
   get_filename_component(_fileName ${SCRIPT} NAME)
   configure_file(${SCRIPT}


### PR DESCRIPTION
When using svn version 1.6, cmake will glob the '.svn' folder and complain. This is a quick fix for it.
