### PR TITLE
COMP: Avoid warnings about the use of uninitialized values.

### DIFF
--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -762,9 +762,23 @@ void GenerateTCLAP(std::ostream &sout, ModuleDescription &module)
           sout << "Temp";
           }
         
+        const std::string cppType = pit->GetCPPType();
         if (!HasDefault(*pit) &&
-            (*pit).GetCPPType() != "bool")
+            cppType != "bool")
           {
+          // Initialized to avoid compiler warnings.
+          if (cppType.compare("int") == 0)
+            {
+            sout << " = 0";
+            }
+          else if (cppType.compare("float") == 0)
+            {
+            sout << " = 0.0f";
+            }
+          else if (cppType.compare("double") == 0)
+            {
+            sout << " = 0.0";
+            }
           sout << ";"
                << EOL << std::endl;
           }

--- a/GenerateCLP/Testing/CLPExample1.xml
+++ b/GenerateCLP/Testing/CLPExample1.xml
@@ -98,6 +98,17 @@
         <step>50.0</step>
       </constraints>
     </double>
+
+    <integer>
+      <name>DownsamplingFactor</name>
+      <description>Downsample the fixed and moving input images by this factor.</description>
+      <label>Downsampling Factor</label>
+      <constraints>
+        <minimum>1</minimum>
+        <maximum>50000</maximum>
+      </constraints>
+    </integer>
+
   </parameters>
 
   <parameters>

--- a/ModuleDescriptionParser/Testing/TestData/ParserTest1.xml
+++ b/ModuleDescriptionParser/Testing/TestData/ParserTest1.xml
@@ -65,7 +65,7 @@
       <label>Learning Rates</label>
       <default>0.005,0.001,0.0005,0.0002</default>
     </float-vector>
-    
+
     <double>
       <name>TranslationScale</name>
       <longflag>--translationscale</longflag>
@@ -79,6 +79,17 @@
         <step>50.0</step>
       </constraints>
     </double>
+
+    <integer>
+      <name>DownsamplingFactor</name>
+      <description>Downsample the fixed and moving input images by this factor.</description>
+      <label>Downsampling Factor</label>
+      <constraints>
+        <minimum>1</minimum>
+        <maximum>50000</maximum>
+      </constraints>
+    </integer>
+
   </parameters>
 
   <parameters>


### PR DESCRIPTION
Compilers may warn oub the use of possible uninitalized value,
so assign integer, float, and double parameters to zero if
there is no default value.
