### PR TITLE
Bad initialization of the ModuleDescription

### DIFF
--- a/ModuleDescriptionParser/ModuleDescription.cxx
+++ b/ModuleDescriptionParser/ModuleDescription.cxx
@@ -40,6 +40,8 @@ ModuleDescription::ModuleDescription()
   std::stringstream ss;
   ss << (unsigned short) -1;
   ss >> this->Index;
+
+  this->ProcessInformation.Initialize();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
The module description should initialized the structure in its constructor.
