### PR TITLE
ENH: Add FindJsonCpp.cmake.

### DIFF
--- a/CMake/FindJsonCpp.cmake
+++ b/CMake/FindJsonCpp.cmake
@@ -1,0 +1,48 @@
+##############################################################################
+#
+# Initially developed for:   TubeTK
+#
+# Copyright 2013 Kitware Inc. 28 Corporate Drive,
+# Clifton Park, NY, 12065, USA.
+#
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
+
+if( JsonCpp_DIR )
+  if( EXISTS ${JsonCpp_DIR}/CMakeCache.txt )
+    file( STRINGS ${JsonCpp_DIR}/CMakeCache.txt _source_dir_def REGEX "jsoncpp_SOURCE_DIR" )
+    string( REGEX REPLACE "[^=]+[=]" "" _source_dir "${_source_dir_def}" )
+    set( _jsoncpp_include_dir "${_source_dir}/include" )
+  endif()
+  set( _jsoncpp_library ${JsonCpp_DIR}/lib )
+endif( JsonCpp_DIR )
+
+find_path( JsonCpp_INCLUDE_DIR NAMES json/json.h
+  HINTS ${_jsoncpp_include_dir}
+  PATH_SUFFIXES jsoncpp )
+
+find_library( JsonCpp_LIBRARY NAMES jsoncpp libjsoncpp
+  HINTS ${_jsoncpp_library} )
+
+set( JsonCpp_INCLUDE_DIRS ${JsonCpp_INCLUDE_DIR} )
+set( JsonCpp_LIBRARIES ${JsonCpp_LIBRARY} )
+
+include( FindPackageHandleStandardArgs )
+
+find_package_handle_standard_args( JsonCpp DEFAULT_MSG JsonCpp_LIBRARIES
+  JsonCpp_INCLUDE_DIRS )
+
+mark_as_advanced( JsonCpp_INCLUDE_DIR JsonCpp_LIBRARY )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(SlicerExecutionModel)
 cmake_minimum_required(VERSION 2.8.2)
 #-----------------------------------------------------------------------------
 
+set(CMAKE_MODULE_PATH ${SlicerExecutionModel_SOURCE_DIR}/CMake ${CMAKE_MODULE_PATH})
+
 if(DEFINED SlicerExecutionModel_INSTALL_BIN_DIR)
   set(GenerateCLP_INSTALL_BIN_DIR ${SlicerExecutionModel_INSTALL_BIN_DIR})
   set(ModuleDescriptionParser_INSTALL_BIN_DIR ${SlicerExecutionModel_INSTALL_BIN_DIR})


### PR DESCRIPTION
Since upstream has not committed a jsoncpp-config.cmake, this is helpful for
finding JsonCpp, especially when JsonCpp_DIR is passed a system version is
available.
