### PR TITLE
BUG: Find JsonCpp library with in a Visual Studio build tree.

### DIFF
--- a/CMake/FindJsonCpp.cmake
+++ b/CMake/FindJsonCpp.cmake
@@ -27,7 +27,11 @@ if( JsonCpp_DIR )
     string( REGEX REPLACE "[^=]+[=]" "" _source_dir "${_source_dir_def}" )
     set( _jsoncpp_include_dir "${_source_dir}/include" )
   endif()
-  set( _jsoncpp_library ${JsonCpp_DIR}/lib )
+  set( _jsoncpp_library ${JsonCpp_DIR}/lib
+    ${JsonCpp_DIR}/lib/Release
+    ${JsonCpp_DIR}/lib/MinSizeRel
+    ${JsonCpp_DIR}/lib/RelWithDebInfo
+    ${JsonCpp_DIR}/lib/Debug )
 endif( JsonCpp_DIR )
 
 find_path( JsonCpp_INCLUDE_DIR NAMES json/json.h


### PR DESCRIPTION
The configuration names are appended to the build path.

@jcfr @aylward
