### PR TITLE
BUG: Missing "bspline" as a transform type choice in error message

### DIFF
--- a/ModuleDescriptionParser/ModuleDescriptionParser.cxx
+++ b/ModuleDescriptionParser/ModuleDescriptionParser.cxx
@@ -899,7 +899,7 @@ startElement(void *userData, const char *element, const char **attrs)
           }
         else
           {
-          std::string error("ModuleDescriptionParser Error: \"" + std::string(attrs[2*attr+1]) + "\" is not a valid value for the attribute \"" + "type" + "\". Only \"linear\" and \"nonlinear\" are accepted.");
+          std::string error("ModuleDescriptionParser Error: \"" + std::string(attrs[2*attr+1]) + "\" is not a valid value for the attribute \"" + "type" + "\". Only \"linear\", \"bspline\" and \"nonlinear\" are accepted.");
           if (ps->ErrorDescription.size() == 0)
             {
             ps->ErrorDescription = error;


### PR DESCRIPTION
There are 3 possible choices for the type of transform (see link below), but the error message only shows 2: "linear" and "nonlinear"
https://github.com/Slicer/SlicerExecutionModel/blob/master/ModuleDescriptionParser/ModuleDescriptionParser.cxx#L894-L896
