### PR TITLE
BUG: Output vector argument should not be assigned.

### DIFF
--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -1692,6 +1692,11 @@ void GenerateTCLAPAssignment(std::ostream & sout, const ModuleDescription & modu
          pit != git->GetParameters().end();
          ++pit)
       {
+      if ((*pit).IsReturnParameter())
+        {
+        continue;
+        }
+
       if (NeedsTemp(*pit) && pit->GetMultiple() != "true")
         {
         if( onlyIfSet )

--- a/GenerateCLP/Testing/CLPExample1.xml
+++ b/GenerateCLP/Testing/CLPExample1.xml
@@ -135,6 +135,12 @@
       <index>2</index>
       <description>Resampled Moving Image</description>
     </file>
+    <float-vector>
+      <name>CostFunctionProgression</name>
+      <description>Cost function value progression</description>
+      <label>Cost Function Progression</label>
+      <channel>output</channel>
+    </float-vector>
   </parameters>
 
 </executable>


### PR DESCRIPTION
Assignment to a required return parameter should not be assigned, and results
in a compilation.  Skip as already is done with the non-vector arguments
(lines 1650-1662 of GenerateCLP.cxx).

The missing condition is added to the test suite.

This was detected when adding ParameterSerializer support to Slicer in the ExecutionModelTour example.
