### PR TITLE
Allow for reference attribute for geometries.

### DIFF
--- a/ModuleDescriptionParser/ModuleDescriptionParser.cxx
+++ b/ModuleDescriptionParser/ModuleDescriptionParser.cxx
@@ -1146,6 +1146,10 @@ startElement(void *userData, const char *element, const char **attrs)
         {
         parameter->SetFileExtensionsAsString(attrs[2*attr+1]);
         }
+      else if ((strcmp(attrs[2*attr], "reference") == 0))
+        {
+        parameter->SetReference(attrs[2*attr+1]);
+        }
       else
         {
         std::string error("ModuleDescriptionParser Error: \"" + std::string(attrs[2*attr]) + "\" is not a valid attribute for \"" + name + "\". Only \"multiple\", \"type\", and \"fileExtensions\" are accepted.");


### PR DESCRIPTION
We use the reference attribute to keep info on related data. This is allowed for 'image' but not for 'geometry'. This request allows it for 'geometry'.
