### PR TITLE
BUG: Allow projects to specify their own list of ITK COMPONENTS. #35

### DIFF
--- a/GenerateCLP/UseGenerateCLP.cmake.in
+++ b/GenerateCLP/UseGenerateCLP.cmake.in
@@ -18,5 +18,7 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ${ModuleDescriptionParser_ITK_COMPONENTS}
   )
 find_package(ITK 4.5 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
+# Allow other projects to specify a different list of COMPONENTS
+set(ITK_FOUND FALSE)
 
 include(${GenerateCLP_CMAKE_DIR}/GenerateCLP.cmake)


### PR DESCRIPTION
Setting ITK_FOUND to FALSE after calling find_package(ITK COMPONENTS
${components}) will cause CMake to re-run the find_package process with
a new set of COMPONENTS.
