### PR TITLE
COMP: save ITK_{LIBRARIES,INCLUDE_DIRS,LIBRARY_DIRS} in UseGenerateCLP.c...

### DIFF
--- a/CMake/SEMMacroBuildCLI.cmake
+++ b/CMake/SEMMacroBuildCLI.cmake
@@ -97,7 +97,6 @@ macro(SEMMacroBuildCLI)
 
   set(CLP ${LOCAL_SEM_NAME})
 
-  # SlicerExecutionModel
   find_package(SlicerExecutionModel REQUIRED GenerateCLP)
   include(${GenerateCLP_USE_FILE})
 

--- a/GenerateCLP/UseGenerateCLP.cmake.in
+++ b/GenerateCLP/UseGenerateCLP.cmake.in
@@ -17,7 +17,28 @@ include(${ModuleDescriptionParser_USE_FILE})
 set(${PROJECT_NAME}_ITK_COMPONENTS
   ${ModuleDescriptionParser_ITK_COMPONENTS}
   )
-find_package(ITK 4.5 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
+
+#
+# The following is needed because if find_package(ITK COMPONENTS) has already been called,
+# calling it again here will nuke the existing modules list.
+set(ITK_COMPONENTS_TO_FIND ${${PROJECT_NAME}_ITK_COMPONENTS})
+
+if(ITK_FOUND)
+  foreach(x LIBRARIES INCLUDE_DIRS LIBRARY_DIRS)
+    set(PUSH_${x} ${ITK_${x}})
+  endforeach()
+endif()
+
+find_package(ITK 4.5 COMPONENTS ${ITK_COMPONENTS_TO_FIND} REQUIRED)
+
+foreach(x LIBRARIES INCLUDE_DIRS LIBRARY_DIRS)
+  if(PUSH_${x})
+    set(_TEMP_${x} ${ITK_${x}} ${PUSH_${x}})
+    list(REMOVE_DUPLICATES _TEMP_${x})
+    set(ITK_${x} ${_TEMP_${x}})
+  endif()
+endforeach()
+
 # Allow other projects to specify a different list of COMPONENTS
 set(ITK_FOUND FALSE)
 


### PR DESCRIPTION
Repeated calls to SEMMacroBuildCLI would screw up the library and
include directory variables from previous calls to find_package(ITK).

This change saves the values -- if set -- of ITK_LIBRARIES,
ITK_INCLUDE_DIRS, and ITK_LIBRARY_DIRS, calls find_package(ITK)
and then merges the list variables.
