### PR TITLE
ENH: Pre283CMakeParseArguments.cmake should only be included for version...

### DIFF
--- a/CMake/SEMMacroBuildCLI.cmake
+++ b/CMake/SEMMacroBuildCLI.cmake
@@ -2,7 +2,7 @@
 # Depends on:
 #  CMakeParseArguments.cmake from Cmake 2.8.4 or greater
 #
-if(CMAKE_PATCH_VERSION LESS 3)
+if(CMAKE_VERSION VERSION_LESS 2.8.3)
   include(${SlicerExecutionModel_CMAKE_DIR}/Pre283CMakeParseArguments.cmake)
 else()
   include(CMakeParseArguments)


### PR DESCRIPTION
...s of CMake before 2.8.3

Previously, it was only comparing the patch number of CMake to know whether Pre283CMakeParseArguments.cmake should be included or not. It now compares the entire version number of CMake to verify if the current version is less recent than 2.8.3 .