### PR TITLE
COMP: Add missing link dependancy for ITKExpat

### DIFF
--- a/ModuleDescriptionParser/CMakeLists.txt
+++ b/ModuleDescriptionParser/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKCommon# For itksys
   ITKIOXML # For ITKEXPAT
+  ITKExpat # For Expat library
   )
 find_package(ITK 4.3 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
 include(${ITK_USE_FILE})


### PR DESCRIPTION
Previous transitive contamination of the library
linkage would cause nearly all libraries to depend
on each other.  As we fix this in ITK proper (work
by Zach Williamson), we need to set the COMPONENTS
to include the items that we use.

In this example, we need ITKExpat library functions,
so including ITKIOExpat no longer transatively includes
ITKExpat (third party) publicly to child projects.  This
means that it must be included directly. NOTE, Had we used
only ITKIOExpat functions, this would not be necessary.