### PR TITLE
ENH: Add Docker Test file

### DIFF
--- a/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
+++ b/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
@@ -3,26 +3,17 @@ MAINTAINER Insight Software Consortium <community@itk.org>
 
 RUN apt-get update && apt-get install -y \
   build-essential \
-  curl \
   cmake \
   git \
-  libexpat1-dev \
-  libhdf5-dev \
-  libjpeg-dev \
-  libpng12-dev \
-  libpython3-dev \
-  libtiff5-dev \
   python \
   ninja-build \
   wget \
-  vim \
-  zlib1g-dev
+  vim
 
 RUN mkdir -p /usr/src/SlicerExecutionModel-build
 WORKDIR /usr/src
 
-# 2015-09-24
-ENV ITK_GIT_TAG cf05d9658da5f27c3ad6652028f563b50cf194b2
+ENV ITK_GIT_TAG v4.8.0
 RUN git clone git://itk.org/ITK.git && \
   cd ITK && \
   git checkout ${ITK_GIT_TAG} && \
@@ -38,10 +29,10 @@ RUN git clone git://itk.org/ITK.git && \
     -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
     -DITK_LEGACY_REMOVE:BOOL=ON \
     -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF \
-    -DITK_USE_SYSTEM_LIBRARIES:BOOL=ON \
+    -DITK_USE_SYSTEM_LIBRARIES:BOOL=OFF \
     -DModule_ITKCommon:BOOL=ON \
     -DModule_ITKIOXML:BOOL=ON \
+    -DModule_ITKExpat:BOOL=ON \
     ../ITK && \
   ninja install && \
   rm -rf ITK ITK-build
-

--- a/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/build.sh
+++ b/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Extract tag
+script_dir="`cd $(dirname $0); pwd`"
+image_tag="`echo $script_dir | rev | cut -d'/' -f 1 | rev | cut -d'-' -f 2-`"
+# Run common build script
+$script_dir/../Docker/build.sh $image_tag $script_dir

--- a/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/run.sh
+++ b/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Extract tag
+script_dir="`cd $(dirname $0); pwd`"
+image_tag="`echo $script_dir | rev | cut -d'/' -f 1 | rev | cut -d'-' -f 2-`"
+# Run common run script
+$script_dir/../Docker/run.sh $image_tag

--- a/test/Docker/Dockerfile
+++ b/test/Docker/Dockerfile
@@ -1,0 +1,47 @@
+FROM debian:8
+MAINTAINER Insight Software Consortium <community@itk.org>
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  curl \
+  cmake \
+  git \
+  libexpat1-dev \
+  libhdf5-dev \
+  libjpeg-dev \
+  libpng12-dev \
+  libpython3-dev \
+  libtiff5-dev \
+  python \
+  ninja-build \
+  wget \
+  vim \
+  zlib1g-dev
+
+RUN mkdir -p /usr/src/SlicerExecutionModel-build
+WORKDIR /usr/src
+
+# 2015-09-24
+ENV ITK_GIT_TAG cf05d9658da5f27c3ad6652028f563b50cf194b2
+RUN git clone git://itk.org/ITK.git && \
+  cd ITK && \
+  git checkout ${ITK_GIT_TAG} && \
+  cd ../ && \
+  mkdir ITK-build && \
+  cd ITK-build && \
+  cmake \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+    -DBUILD_EXAMPLES:BOOL=OFF \
+    -DBUILD_TESTING:BOOL=OFF \
+    -DBUILD_SHARED_LIBS:BOOL=ON \
+    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
+    -DITK_LEGACY_REMOVE:BOOL=ON \
+    -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF \
+    -DITK_USE_SYSTEM_LIBRARIES:BOOL=ON \
+    -DModule_ITKCommon:BOOL=ON \
+    -DModule_ITKIOXML:BOOL=ON \
+    ../ITK && \
+  ninja install && \
+  rm -rf ITK ITK-build
+

--- a/test/Docker/build.sh
+++ b/test/Docker/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker build -t slicer/slicerexecutionmodel $script_dir

--- a/test/Docker/build.sh
+++ b/test/Docker/build.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
-script_dir="`cd $(dirname $0); pwd`"
+die() {
+  echo "Error: $@" 1>&2
+  exit 1;
+}
 
-docker build -t slicer/slicerexecutionmodel $script_dir
+if [ ! $1 ];
+then
+  die "Empty Image Tag "
+fi
+
+if [ ! $2 ];
+then
+  die "Empty Path to Dockerfile "
+fi
+
+lower_case_tag="`echo $1 | tr "[:upper:]" "[:lower:]" `"
+docker build -t slicer/slicerexecutionmodel:$lower_case_tag $2

--- a/test/Docker/run.sh
+++ b/test/Docker/run.sh
@@ -2,8 +2,15 @@
 
 script_dir="`cd $(dirname $0); pwd`"
 
+if [ ! $1 ];
+then
+  die "Empty Image Tag "
+fi
+
+lower_case_tag="`echo $1 | tr "[:upper:]" "[:lower:]" `"
+
 docker run \
   --rm \
   -v $script_dir/../..:/usr/src/SlicerExecutionModel \
-    slicer/slicerexecutionmodel \
+    slicer/slicerexecutionmodel:$lower_case_tag \
       /usr/src/SlicerExecutionModel/test/Docker/test.sh

--- a/test/Docker/run.sh
+++ b/test/Docker/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker run \
+  --rm \
+  -v $script_dir/../..:/usr/src/SlicerExecutionModel \
+    slicer/slicerexecutionmodel \
+      /usr/src/SlicerExecutionModel/test/Docker/test.sh

--- a/test/Docker/test.sh
+++ b/test/Docker/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This is a script to build the project and run the test suite in the base
+# Docker container.
+
+die() {
+  echo "Error: $@" 1>&2
+  exit 1;
+}
+
+cd /usr/src/SlicerExecutionModel-build || die "Could not cd into the build directory"
+
+cmake \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+    /usr/src/SlicerExecutionModel || die "CMake configuration failed"
+ctest -VV -D Experimental || die "ctest failed"


### PR DESCRIPTION
This commit add a Docker file allowing to easily build
and test the project. It contains the recipe allowing to
build ITK so that SlicerExecutionModel can quickly be
configured, built and tested.

This PR reorganize part of #46 to only include docker changes