### PR TITLE
ENH: Add circleCI files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 SlicerExecutionModel
 ====================
 
+[![Circle CI](https://circleci.com/gh/Slicer/SlicerExecutionModel.svg?style=svg)](https://circleci.com/gh/Slicer/SlicerExecutionModel)
+
 Overview
 --------
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+    - docker pull slicer/slicerexecutionmodel:itk-v4.8.0_use_system_libraries-off
+
+test:
+  override:
+    - mkdir ~/SlicerExecutionModel-build
+    - docker run -v ~/SlicerExecutionModel:/usr/src/SlicerExecutionModel -v ~/SlicerExecutionModel-build:/usr/src/SlicerExecutionModel-build slicer/slicerexecutionmodel:itk-v4.8.0_use_system_libraries-off /usr/src/SlicerExecutionModel/test/Docker/test.sh
+


### PR DESCRIPTION
This commit add files to perform continuous integration testing
using the Docker container set up in PR #49.
It contains the recipe to perform tests using circleCI and provides
the result in the README section.

This PR reorganize part of #46 to only include circleCI changes