### PR TITLE
ENH: Support submission of test results on CDash

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,9 @@
+set(CTEST_PROJECT_NAME "SlicerExecutionModel")
+set(CTEST_NIGHTLY_START_TIME "3:00:00 UTC")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "slicer.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=SlicerExecutionModel")
+set(CTEST_DROP_SITE_CDASH TRUE)
+
+


### PR DESCRIPTION
This commit adds CTestConfig.cmake file that will tell ctest
where to submit its results.

Results will be posted here:

 http://slicer.cdash.org/index.php?project=SlicerExecutionModel