### PR TITLE
ENH: Add Relevant BUILDNAME for CDash submission

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,14 +1,16 @@
 machine:
   services:
     - docker
+  environment:
+    DOCKER_TAG_1: itk-v4.8.0_use_system_libraries-off
 
 dependencies:
   override:
     - docker info
-    - docker pull slicer/slicerexecutionmodel:itk-v4.8.0_use_system_libraries-off
+    - docker pull slicer/slicerexecutionmodel:$DOCKER_TAG_1
 
 test:
   override:
     - mkdir ~/SlicerExecutionModel-build
-    - docker run -v ~/SlicerExecutionModel:/usr/src/SlicerExecutionModel -v ~/SlicerExecutionModel-build:/usr/src/SlicerExecutionModel-build slicer/slicerexecutionmodel:itk-v4.8.0_use_system_libraries-off /usr/src/SlicerExecutionModel/test/Docker/test.sh
+    - docker run -v ~/SlicerExecutionModel:/usr/src/SlicerExecutionModel -v ~/SlicerExecutionModel-build:/usr/src/SlicerExecutionModel-build slicer/slicerexecutionmodel:$DOCKER_TAG_1 /usr/src/SlicerExecutionModel/test/Docker/test.sh $DOCKER_TAG_1
 

--- a/test/Docker/run.sh
+++ b/test/Docker/run.sh
@@ -13,4 +13,4 @@ docker run \
   --rm \
   -v $script_dir/../..:/usr/src/SlicerExecutionModel \
     slicer/slicerexecutionmodel:$lower_case_tag \
-      /usr/src/SlicerExecutionModel/test/Docker/test.sh
+      /usr/src/SlicerExecutionModel/test/Docker/test.sh $lower_case_tag

--- a/test/Docker/test.sh
+++ b/test/Docker/test.sh
@@ -13,5 +13,6 @@ cd /usr/src/SlicerExecutionModel-build || die "Could not cd into the build direc
 cmake \
   -G Ninja \
   -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DBUILDNAME:STRING=$1 \
     /usr/src/SlicerExecutionModel || die "CMake configuration failed"
 ctest -VV -D Experimental || die "ctest failed"


### PR DESCRIPTION
This commit enables continuous integration testing with docker to
submit results on the dashboard with a more relevant build name.
This build name corresponds to the docker image tag that was previously
set up in PR #49 to specify the build option used by the image.

This commit has been tagged as WIP because the process has only been
tested using the Docker script run.sh. When making the PR, the circleCI
process will be automatically tested.