### PR TITLE
BUG: Wrong unparsed arguments variable name

### DIFF
--- a/CMake/SEMMacroBuildCLI.cmake
+++ b/CMake/SEMMacroBuildCLI.cmake
@@ -49,8 +49,8 @@ macro(SEMMacroBuildCLI)
       message(STATUS "${curr_opt} = ${LOCAL_SEM_${curr_opt}}")
     endforeach()
   endif()
-  if(LOCAL_SEM_INSTALL_UNPARSED_ARGUMENTS)
-    message(AUTHOR_WARNING "Unparsed arguments given [${LOCAL_SEM_INSTALL_UNPARSED_ARGUMENTS}]")
+  if(LOCAL_SEM_UNPARSED_ARGUMENTS)
+    message(AUTHOR_WARNING "Unparsed arguments given [${LOCAL_SEM_UNPARSED_ARGUMENTS}]")
   endif()
   # --------------------------------------------------------------------------
   # Sanity checks


### PR DESCRIPTION
Unparsed arguments are saved in <prefix>_UNPARSED_ARGUMENTS [1]. In this case, <prefix> is LOCAL_SEM, so the variable containing the unparsed arguments is called LOCAL_SEM_UNPARSED_ARGUMENTS.

[1] https://cmake.org/cmake/help/v3.0/module/CMakeParseArguments.html