### PR TITLE
ENH: cxx and executable can have different names.

### DIFF
--- a/CMake/SEMMacroBuildCLI.cmake
+++ b/CMake/SEMMacroBuildCLI.cmake
@@ -12,6 +12,7 @@ macro(SEMMacroBuildCLI)
   set(options
     EXECUTABLE_ONLY
     NO_INSTALL VERBOSE
+    DISABLE_DEFAULT_CXX_FILE
     )
   set(oneValueArgs
     NAME LOGO_HEADER
@@ -102,7 +103,10 @@ macro(SEMMacroBuildCLI)
   find_package(SlicerExecutionModel REQUIRED GenerateCLP)
   include(${GenerateCLP_USE_FILE})
 
-  set(${CLP}_SOURCE ${CLP}.cxx ${LOCAL_SEM_ADDITIONAL_SRCS})
+  set(${CLP}_SOURCE ${LOCAL_SEM_ADDITIONAL_SRCS})
+  if(NOT LOCAL_SEM_DISABLE_DEFAULT_CXX_FILE)
+    list(APPEND ${CLP}_SOURCE ${CLP}.cxx)
+  endif()
   generateclp(${CLP}_SOURCE ${cli_xml_file} ${LOCAL_SEM_LOGO_HEADER})
 
   if(DEFINED LOCAL_SEM_LINK_DIRECTORIES)


### PR DESCRIPTION
Previously, each CLI needed to have a cxx file called the same as the given executable name. This was restricting the possibility to name an executable differently based, for example, on configuration or compilation options. This patch introduced a new option to disable this requirement. This allows SEMMacroBuildCLI to stay backward compatible while allowing more flexibiliy in the naming of the cxx files and the executable [1].

[1] https://docs.google.com/a/kitware.com/document/d/1Wkl7RFVb87ZbcgZnSQ4nmyM2bFEQUN1xT-Q5ALLJh8w/edit?usp=sharing
