### PR TITLE
ENH: Use hidden visibility on the CLI library.

### DIFF
--- a/CMake/SEMMacroBuildCLI.cmake
+++ b/CMake/SEMMacroBuildCLI.cmake
@@ -128,6 +128,19 @@ macro(SEMMacroBuildCLI)
 
   add_library(${CLP}Lib ${cli_library_type} ${${CLP}_SOURCE})
   set_target_properties(${CLP}Lib PROPERTIES COMPILE_FLAGS "-Dmain=ModuleEntryPoint")
+  if(NOT WIN32 AND NOT CYGWIN AND ${cli_library_type} STREQUAL "SHARED")
+    include(GenerateExportHeader)
+    # The generated export header is not used, but this call is required to
+    # define COMPILER_HAS_HIDDEN_VISIBILITY and USE_COMPILER_HIDDEN_VISIBILITY
+    generate_export_header(${CLP}Lib)
+    if(COMPILER_HAS_HIDDEN_VISIBILITY AND USE_COMPILER_HIDDEN_VISIBILITY)
+      set_property(TARGET ${CLP}Lib
+        APPEND_STRING PROPERTY COMPILE_FLAGS " -DMODULE_HIDDEN_VISIBILITY")
+      set_target_properties(${CLP}Lib PROPERTIES CXX_VISIBILITY_PRESET hidden)
+      set_target_properties(${CLP}Lib PROPERTIES C_VISIBILITY_PRESET hidden)
+      set_target_properties(${CLP}Lib PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+    endif()
+  endif()
   if(DEFINED LOCAL_SEM_TARGET_LIBRARIES)
     target_link_libraries(${CLP}Lib ${LOCAL_SEM_TARGET_LIBRARIES})
   endif()

--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -666,6 +666,8 @@ void GenerateExports(std::ostream &sout)
 {
   sout << "#ifdef _WIN32" << std::endl;
   sout << "#define Module_EXPORT __declspec(dllexport)" << std::endl;
+  sout << "#elif defined(MODULE_HIDDEN_VISIBILITY)" << std::endl;
+  sout << "#define Module_EXPORT __attribute__((visibility(\"default\")))" << std::endl;
   sout << "#else" << std::endl;
   sout << "#define Module_EXPORT" << std::endl;
   sout << "#endif" << std::endl;


### PR DESCRIPTION
For non-Windows builds, use hidden visibiltity on the CLI library when built
as a shared library and when the compiler supports it. This decreases disk
usage and improves load time of the CLI.

On a 3D Slicer MinSizeRel Linux build this:

- Reduces the `lib/Slicer-4.5/cli-modules` directory from 104MB to 89MB
- Reduces Slicer startup time from 20.2sec to 16.2sec