### PR TITLE
BUG: find_package(ITK ...) clobbered existing

### DIFF
--- a/GenerateCLP/UseGenerateCLP.cmake.in
+++ b/GenerateCLP/UseGenerateCLP.cmake.in
@@ -11,14 +11,16 @@ include(${TCLAP_USE_FILE})
 find_package(ModuleDescriptionParser REQUIRED)
 include(${ModuleDescriptionParser_USE_FILE})
 
-#
-# ITK - Import ITK targets required by ModuleDescriptionParser
-#
-set(${PROJECT_NAME}_ITK_COMPONENTS
-  ${ModuleDescriptionParser_ITK_COMPONENTS}
-  )
-find_package(ITK 4.3 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-# Allow other projects to specify a different list of COMPONENTS
-set(ITK_FOUND FALSE)
+if(NOT ITK_FOUND) #Do not clobber existing found version of ITK
+  #
+  # ITK - Import ITK targets required by ModuleDescriptionParser
+  #
+  set(${PROJECT_NAME}_ITK_COMPONENTS
+    ${ModuleDescriptionParser_ITK_COMPONENTS}
+     )
+  find_package(ITK 4.3 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
+  # Allow other projects to specify a different list of COMPONENTS
+  set(ITK_FOUND FALSE)
+endif()
 
 include(${GenerateCLP_CMAKE_DIR}/GenerateCLP.cmake)


### PR DESCRIPTION
The find_package(ITK ...) with limited components caused
this second call to find_package(ITK) within GenerateCLP to
clobber the find_package(ITK) that an end user may have
called previously.  This would cause problems because
the end-user application now would only have access to the
limited set of modules that GenerateCLP needed.