### PR TITLE
COMP: Do not use hidden visibility when ITK is built statically.

### DIFF
--- a/CMake/SEMMacroBuildCLI.cmake
+++ b/CMake/SEMMacroBuildCLI.cmake
@@ -128,7 +128,7 @@ macro(SEMMacroBuildCLI)
 
   add_library(${CLP}Lib ${cli_library_type} ${${CLP}_SOURCE})
   set_target_properties(${CLP}Lib PROPERTIES COMPILE_FLAGS "-Dmain=ModuleEntryPoint")
-  if(NOT WIN32 AND NOT CYGWIN AND ${cli_library_type} STREQUAL "SHARED")
+  if(NOT WIN32 AND NOT CYGWIN AND ${cli_library_type} STREQUAL "SHARED" AND ITK_BUILD_SHARED)
     include(GenerateExportHeader)
     # The generated export header is not used, but this call is required to
     # define COMPILER_HAS_HIDDEN_VISIBILITY and USE_COMPILER_HIDDEN_VISIBILITY


### PR DESCRIPTION
To address:

[ 66%] Linking CXX shared library
/scratch/johnsonhj/src/BT-11/lib/libPerformMetricTestLib.dylib
ld: warning: direct access in _ModuleEntryPoint to global weak symbol typeinfo
for itk::BSplineTransform means the weak symbol cannot be overridden at
runtime. This was likely caused by different translation units being compiled
with different visibility settings.
ld: warning: direct access in itk::BSplineTransform::New() to global weak
symbol typeinfo for itk::BSplineTransform means the weak symbol cannot be
overridden at runtime. This was likely caused by different translation units
being compiled with different visibility settings.
ld: warning: direct access in itk::BSplineTransform::New() to global weak
symbol typeinfo name for itk::BSplineTransform means the weak symbol cannot be
overridden at runtime. This was likely caused by different translation units
being compiled with different visibility settings.
ld: warning: direct access in itk::ImageFileReader,
itk::DefaultConvertPixelTraits
>::EnlargeOutputRequestedRegion(itk::DataObject*) to global weak symbol
>typeinfo for itk::Image means the weak symbol cannot be overridden at
>runtime. This was likely caused by different translation units being compiled
>with different visibility settings.
ld: warning: direct access in itk::ImageSource >::AllocateOutputs() to global
weak symbol typeinfo for itk::ImageBase<3u> means the weak symbol cannot be
overridden at runtime. This was likely caused by different translation units
being compiled with different visibility settings.

It is also causing many test items to fail (due to inability to read HDF5
files).