### PR TITLE
Made implicit conversion explicit (size_t to int).

### DIFF
--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -1504,7 +1504,7 @@ void GenerateTCLAPParse(std::ostream &sout, ModuleDescription &module)
    sout << "     }" << EOL << std::endl;
 
   // Generate the code to parse the command line
-  sout << "    commandLine.parse ( vargs.size(), (char**) &(vargs[0]) );" << EOL << std::endl;
+  sout << "    commandLine.parse ( (int)vargs.size(), (char**) &(vargs[0]) );" << EOL << std::endl;
 
   // Wrapup the block and generate the catch block
   sout << "  }" << EOL << std::endl;

--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -1504,7 +1504,7 @@ void GenerateTCLAPParse(std::ostream &sout, ModuleDescription &module)
    sout << "     }" << EOL << std::endl;
 
   // Generate the code to parse the command line
-  sout << "    commandLine.parse ( (int)vargs.size(), (char**) &(vargs[0]) );" << EOL << std::endl;
+  sout << "    commandLine.parse ( static_cast<int>(vargs.size()), (char**) &(vargs[0]) );" << EOL << std::endl;
 
   // Wrapup the block and generate the catch block
   sout << "  }" << EOL << std::endl;

--- a/GenerateCLP/GenerateCLP.h
+++ b/GenerateCLP/GenerateCLP.h
@@ -301,7 +301,7 @@ try \
      {  \
      vargs.push_back(const_cast<char *>(targs[ac].c_str())); \
      } \
-    commandLine.parse ( vargs.size(), (char**) &(vargs[0]) ); \
+    commandLine.parse ( (int)vargs.size(), (char**) &(vargs[0]) ); \
   } \
 catch ( TCLAP::ArgException & e ) \
   { \

--- a/GenerateCLP/GenerateCLP.h
+++ b/GenerateCLP/GenerateCLP.h
@@ -301,7 +301,7 @@ try \
      {  \
      vargs.push_back(const_cast<char *>(targs[ac].c_str())); \
      } \
-    commandLine.parse ( (int)vargs.size(), (char**) &(vargs[0]) ); \
+    commandLine.parse ( static_cast<int>(vargs.size()), (char**) &(vargs[0]) ); \
   } \
 catch ( TCLAP::ArgException & e ) \
   { \


### PR DESCRIPTION
Fixes `conversion from 'size_t' to 'int', possible loss of data` warning.