### PR TITLE
STYLE: CMakeLists: Finding of threading library is not needed anymore

### DIFF
--- a/ModuleDescriptionParser/CMakeLists.txt
+++ b/ModuleDescriptionParser/CMakeLists.txt
@@ -176,12 +176,6 @@ set(libs
 # Append extra platform dependent libraries required for linking
 #
 
-if(UNIX)
-  set(CMAKE_THREAD_PREFER_PTHREAD 1)
-  find_package(Threads REQUIRED)
-  list(APPEND libs ${CMAKE_THREAD_LIBS_INIT})
-endif()
-
 if(ModuleDescriptionParser_USE_SERIALIZER)
   list(APPEND libs ${ParameterSerializer_LIBRARIES})
 endif()


### PR DESCRIPTION
Initially introduced in Slicer r6773 (ENH: Slicer3 Spring Installation
Clean Up), finding and linking against pthread library is not needed.