### PR TITLE
ENH: Improve JsonCpp support for SlicerExecutionModel

### DIFF
--- a/CMake/FindJsonCpp.cmake
+++ b/CMake/FindJsonCpp.cmake
@@ -27,7 +27,13 @@ if( JsonCpp_DIR )
     string( REGEX REPLACE "[^=]+[=]" "" _source_dir "${_source_dir_def}" )
     set( _jsoncpp_include_dir "${_source_dir}/include" )
   endif()
-  set( _jsoncpp_library ${JsonCpp_DIR}/lib
+  set( _jsoncpp_library
+    ${JsonCpp_DIR}/src/lib_json
+    ${JsonCpp_DIR}/src/lib_json/Release
+    ${JsonCpp_DIR}/src/lib_json/MinSizeRel
+    ${JsonCpp_DIR}/src/lib_json/RelWithDebInfo
+    ${JsonCpp_DIR}/src/lib_json/Debug
+    ${JsonCpp_DIR}/lib
     ${JsonCpp_DIR}/lib/Release
     ${JsonCpp_DIR}/lib/MinSizeRel
     ${JsonCpp_DIR}/lib/RelWithDebInfo

--- a/GenerateCLP/CMakeLists.txt
+++ b/GenerateCLP/CMakeLists.txt
@@ -58,6 +58,10 @@ if(NOT DEFINED GenerateCLP_USE_JSONCPP)
   option(GenerateCLP_USE_JSONCPP "Automatic flags are added to serialize and deserialized the parameters." OFF)
   mark_as_advanced(GenerateCLP_USE_JSONCPP)
 endif()
+if(GenerateCLP_USE_JSONCPP)
+  include_directories(${JsonCpp_INCLUDE_DIRS})
+endif()
+
 if(NOT DEFINED GenerateCLP_USE_SERIALIZER)
   option(GenerateCLP_USE_SERIALIZER "Automatic flags are added to dump the json-ld schema for the parameters." OFF)
   mark_as_advanced(GenerateCLP_USE_SERIALIZER)
@@ -121,6 +125,7 @@ target_link_libraries(${executable_name}
   # Appearently windows does not like static libs mixed with shared libs ModuleDescriptionParser-static
   # A different solution will have to be investigated for makeing GenerateCLP work without
   # shared libs.
+  ${JsonCpp_LIBRARIES}
   ${ParameterSerializer_LIBRARIES}
   ModuleDescriptionParser
   ${ITK_LIBRARIES}

--- a/SlicerExecutionModelConfig.cmake.in
+++ b/SlicerExecutionModelConfig.cmake.in
@@ -10,6 +10,7 @@
 #                    SlicerExecutionModel_USE_GENERATECLP
 #                    SlicerExecutionModel_USE_MODULEDESCRIPTIONPARSER
 #                    SlicerExecutionModel_USE_TCLAP
+#                    SlicerExecutionModel_USE_JSONCPP
 #                    SlicerExecutionModel_USE_SERIALIZER
 
 # Check if components where passed to find_package()
@@ -27,15 +28,27 @@ if(NOT SlicerExecutionModel_FIND_COMPONENTS)
   set(SlicerExecutionModel_USE_TCLAP 1)
 endif()
 
-# SlicerExecutionModel_USE_SERIALIZER is optional and it must be turned on at
+# SlicerExecutionModel_USE_JSONCPP is optional and it must be turned on at
 # build time.
-if(SlicerExecutionModel_USE_SERIALIZER AND NOT "@SlicerExecutionModel_USE_SERIALIZER@")
+set(SlicerExecutionModel_BUILD_WITH_JSONCPP "@SlicerExecutionModel_USE_JSONCPP@")
+if(SlicerExecutionModel_USE_JSONCPP AND NOT SlicerExecutionModel_BUILD_WITH_JSONCPP)
+  message(SEND_ERROR "The JSONCPP COMPONENT for SlicerExecutionModel was requested,
+  but SlicerExecutionModel was not built with SlicerExecutionModel_USE_JSONCPP ON.")
+endif()
+set(SlicerExecutionModel_USE_JSONCPP ${SlicerExecutionModel_BUILD_WITH_JSONCPP})
+
+# SlicerExecutionModel_USE_SERIALIZER is optional and it must be turned on at
+# build time. It also depends on SlicerExecutionModel_USE_JSONCPP.
+set(SlicerExecutionModel_BUILD_WITH_SERIALIZER "@SlicerExecutionModel_USE_SERIALIZER@")
+if(SlicerExecutionModel_USE_SERIALIZER AND NOT SlicerExecutionModel_BUILD_WITH_SERIALIZER)
   message(SEND_ERROR "The SERIALIZER COMPONENT for SlicerExecutionModel was requested,
   but SlicerExecutionModel was not built with SlicerExecutionModel_USE_SERIALIZER ON.")
 endif()
-set(SlicerExecutionModel_USE_SERIALIZER "@SlicerExecutionModel_USE_SERIALIZER@")
-if(SlicerExecutionModel_USE_SERIALIZER)
-  find_package(ParameterSerializer REQUIRED)
+set(SlicerExecutionModel_USE_SERIALIZER ${SlicerExecutionModel_BUILD_WITH_SERIALIZER})
+if(SlicerExecutionModel_USE_SERIALIZER AND NOT SlicerExecutionModel_USE_JSONCPP)
+  message(SEND_ERROR "The SERIALIZER COMPONENT for SlicerExecutionModel was requested,
+  but SlicerExecutionModel it depends on the JSONCPP component.
+  Make sure SlicerExecutionModel_USE_JSONCPP is ON.")
 endif()
 
 # Set SlicerExecutionModel variables
@@ -127,6 +140,8 @@ endif()
 set(ModuleDescriptionParser_DIR ${SlicerExecutionModel_DIR}/ModuleDescriptionParser)
 set(GenerateCLP_DIR ${SlicerExecutionModel_DIR}/GenerateCLP)
 set(TCLAP_DIR ${SlicerExecutionModel_DIR}/tclap)
+set(JsonCpp_DIR "@JsonCpp_DIR@")
+set(ParameterSerializer_DIR "@ParameterSerializer_DIR@")
 
 #
 # Find ModuleDescriptionParser, GenerateCLP and TCLAP so that the associated 
@@ -142,6 +157,20 @@ endif()
 
 if(SlicerExecutionModel_USE_TCLAP)
   find_package(TCLAP REQUIRED)
+endif()
+
+if(SlicerExecutionModel_USE_JSONCPP)
+  # Add FindJsonCpp.cmake to module path
+  set(CMAKE_MODULE_PATH ${SlicerExecutionModel_CMAKE_DIR} ${CMAKE_MODULE_PATH})
+  find_package(JsonCpp REQUIRED)
+
+  if(WIN32)
+    add_definitions(-DJSON_DLL)
+  endif()
+endif()
+
+if(SlicerExecutionModel_USE_SERIALIZER)
+  find_package(ParameterSerializer REQUIRED)
 endif()
 
 set(SlicerExecutionModel_LIBRARY_DIRS


### PR DESCRIPTION
There are a few items here to improve the JsonCpp support for
SlicerExecutionModel:

- FindJsonCpp.cmake:
Add /src/lib_json directory to the list of directories searches for the
json library. This is the default build directory for the jsoncpp library.

- GenerateCLP/CMakeLists.txt:
Add missing include_directory and missing library linkage to JsonCpp.

- SlicerExecutionModelConfig.cmake.in:
Add missing checks for JsonCpp. Also add definition for windows compilation

@jcfr: Would you mind taking a look ?