### PR TITLE
ENH: Improve support for empty arrays

### DIFF
--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -562,11 +562,16 @@ void GenerateDeSerialization( std::ostream & sout,
           }
         else
           {
-          w | "        deserializedVectorFlaggedArgs.push_back(\"" + flag + "\");"
-            | "        Json::Value param = parameters[\"" + groupLabel + "\"][\"" + parameterName + "\"];"
-            | "        std::string value = \"\";"
-            | "        if (param.isArray())"
+          w | "        Json::Value param = parameters[\"" + groupLabel + "\"][\"" + parameterName + "\"];"
+            | "        if (!param.isArray())"
             | "          {"
+            | "          deserializedVectorFlaggedArgs.push_back(\"" + flag + "\");"
+            | "          deserializedVectorFlaggedArgs.push_back(param.asString());"
+            | "          }"
+            | "        else if(param.size() > 0)"
+            | "          {"
+            | "          deserializedVectorFlaggedArgs.push_back(\"" + flag + "\");"
+            | "          std::string value = \"\";"
             | "          for (unsigned int i = 0; i < param.size(); ++i)"
             | "            {"
             | "            value += param[i].asString();"
@@ -575,12 +580,8 @@ void GenerateDeSerialization( std::ostream & sout,
             | "              value += \", \";"
             | "              }"
             | "            }"
-            | "          }"
-            | "        else"
-            | "          {"
-            | "          value = param.asString();"
-            | "          }"
-            | "        deserializedVectorFlaggedArgs.push_back(value);";
+            | "          deserializedVectorFlaggedArgs.push_back(value);"
+            | "          }";
           }
         }
       else

--- a/GenerateCLP/Testing/CLPExample1/CLPExample1.cxx
+++ b/GenerateCLP/Testing/CLPExample1/CLPExample1.cxx
@@ -132,6 +132,14 @@ int main (int argc, char *argv[])
   // DownsamplingFactor
   success &= HasExpectedValue<int>(DownsamplingFactor, 2, 5);
 
+  // MultipleValues
+  if (DefaultMultipleValues.size() != 0)
+    {
+    std::cerr << "Error, unexpected DefaultMultipleValues size, got: "
+      << DefaultMultipleValues.size() << " expected 0." << std::endl;
+    return EXIT_FAILURE;
+    }
+
   // FixedImage
   success &= HasExpectedValue<std::string>(FixedImage, std::string("Head.mha"), std::string("OtherHead.mha"));
 

--- a/GenerateCLP/Testing/CLPExample1/CLPExample1.xml
+++ b/GenerateCLP/Testing/CLPExample1/CLPExample1.xml
@@ -109,6 +109,13 @@
       </constraints>
     </integer>
 
+    <point multiple="true">
+      <name>DefaultMultipleValues</name>
+      <description>Parameter to test the default multiple values parsing.</description>
+      <label>Default Multiple Values</label>
+      <longflag>--defaultMultiple</longflag>
+    </point>
+
   </parameters>
 
   <parameters>


### PR DESCRIPTION
The parsing was including the file from the JSON file even if the array
was empty. To remediate to this, we test for the array size to make
sure it's not empty before adding the flag and the following values.

Testing is improved as well by adding an argument with the "multiple" flag
and making sure it's serialized/deserialized correctly (it should always
be empty).