### PR TITLE
ENH: GenerateCLP: Force GenerateCLPLauncher rebuild on GenerateCLP ch…

### DIFF
--- a/GenerateCLP/CMakeLists.txt
+++ b/GenerateCLP/CMakeLists.txt
@@ -179,12 +179,20 @@ set(GenerateCLP_FORWARD_DIR_INSTALL "..")
 # --------------------------------------------------------------------------
 # Build launcher
 # --------------------------------------------------------------------------
+set(GenerateCLPLauncher_SOURCE
+  ${CMAKE_CURRENT_BINARY_DIR}/GenerateCLPLauncher.c
+  )
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/GenerateCLPLauncher.c.in
-  ${CMAKE_CURRENT_BINARY_DIR}/GenerateCLPLauncher.c
+  ${GenerateCLPLauncher_SOURCE}
   @ONLY)
+add_custom_command(TARGET GenerateCLP POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E touch ${GenerateCLPLauncher_SOURCE}
+  COMMENT "Force GenerateCLPLauncher to rebuild after GenerateCLP was modified"
+  )
 add_executable(GenerateCLPLauncher
-  ${CMAKE_CURRENT_BINARY_DIR}/GenerateCLPLauncher.c)
+  ${GenerateCLPLauncher_SOURCE}
+  )
 list(APPEND targets_to_export GenerateCLPLauncher)
 add_dependencies(GenerateCLPLauncher GenerateCLP)
 


### PR DESCRIPTION
…ange

Previously, the launcher did not rebuild when the GenerateCLP executable
changed. This caused other application that have a dependency on the
launcher to NOT regenerate their CLP header files. The user would have
to specifically ask for a rebuild.

By forcing the launcher to rebuild whenever GenerateCLP has changed, we
make sure that the applications will regenerate their CLP header file.