### PR TITLE
ENH: Uniformize the use of JsonCpp with VTK

### DIFF
--- a/GenerateCLP/CMakeLists.txt
+++ b/GenerateCLP/CMakeLists.txt
@@ -160,17 +160,26 @@ endif()
 # where the binary is actually not in the same directory as the shared
 # libraries it depends on.
 #
+if(JsonCpp_FOUND)
+  get_filename_component(json_library_dir ${JsonCpp_LIBRARY} DIRECTORY)
+  set(json_forward_path_build
+     "\"${json_library_dir}\" CONFIG_DIR_POST, \\
+     \"${json_library_dir}\", \\"
+    )
+  set(json_forward_path_install "\"${json_library_dir}\", \\")
+endif()
+
 set(GenerateCLP_FORWARD_DIR_BUILD "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 set(GenerateCLP_FORWARD_PATH_BUILD " \\
    \".\" CONFIG_DIR_POST, \\
    \"${ITK_DIR}/bin\" CONFIG_DIR_POST, \\
-   \"${JsonCpp_DIR}/src/lib_json\" CONFIG_DIR_POST, \\
+   ${json_forward_path_build}
    \"${ModuleDescriptionParser_DIR}/bin\" CONFIG_DIR_POST \\
 ")
 set(GenerateCLP_FORWARD_PATH_INSTALL " \\
    \".\", \\
    \"${ITK_DIR}/bin\", \\
-   \"${JsonCpp_DIR}/src/lib_json\", \\
+   ${json_forward_path_install}
    \"${ModuleDescriptionParser_DIR}/bin\" \\
 ")
 set(GenerateCLP_FORWARD_EXE GenerateCLP)

--- a/GenerateCLP/GenerateCLPConfig.cmake.in
+++ b/GenerateCLP/GenerateCLPConfig.cmake.in
@@ -10,7 +10,8 @@ set(GenerateCLP_USE_SERIALIZER "@GenerateCLP_USE_SERIALIZER@")
 set(TCLAP_DIR "@TCLAP_DIR@")
 set(ModuleDescriptionParser_DIR "@ModuleDescriptionParser_DIR@")
 set(ITK_DIR "@ITK_DIR_CONFIG@")
-set(JsonCpp_DIR "@JsonCpp_DIR@")
+set(JsonCpp_INCLUDE_DIR "@JsonCpp_INCLUDE_DIR@")
+set(JsonCpp_LIBRARY "@JsonCpp_LIBRARY@")
 set(ParameterSerializer_DIR "@ParameterSerializer_DIR@")
 
 find_program(GENERATECLP_EXE

--- a/GenerateCLP/Testing/CMake/GenerateCLPTestPrerequisites.cmake.in
+++ b/GenerateCLP/Testing/CMake/GenerateCLPTestPrerequisites.cmake.in
@@ -8,7 +8,8 @@ set(generateclp_cmake_generator "@CMAKE_GENERATOR@")
 set(GenerateCLP_BINARY_DIR "@GenerateCLP_BINARY_DIR@")
 
 set(GenerateCLP_USE_JSONCPP @GenerateCLP_USE_JSONCPP@)
-set(JsonCpp_DIR "@JsonCpp_DIR@")
+set(JsonCpp_INCLUDE_DIR "@JsonCpp_INCLUDE_DIR@")
+set(JsonCpp_LIBRARY "@JsonCpp_LIBRARY@")
 
 set(JsonCpp_CMAKE_MODULE_PATH "@SlicerExecutionModel_SOURCE_DIR@/CMake")
 

--- a/SlicerExecutionModelConfig.cmake.in
+++ b/SlicerExecutionModelConfig.cmake.in
@@ -140,7 +140,8 @@ endif()
 set(ModuleDescriptionParser_DIR ${SlicerExecutionModel_DIR}/ModuleDescriptionParser)
 set(GenerateCLP_DIR ${SlicerExecutionModel_DIR}/GenerateCLP)
 set(TCLAP_DIR ${SlicerExecutionModel_DIR}/tclap)
-set(JsonCpp_DIR "@JsonCpp_DIR@")
+set(JsonCpp_INCLUDE_DIR "@JsonCpp_INCLUDE_DIR@")
+set(JsonCpp_LIBRARY "@JsonCpp_LIBRARY@")
 set(ParameterSerializer_DIR "@ParameterSerializer_DIR@")
 
 #


### PR DESCRIPTION
VTK does not use JsonCpp_DIR. In an effort to be consistent across
projects, we should only refer to JsonCpp_INCLUDE_DIR and JsonCpp_LIBRARY.

This is futhermore reinforce that JsonCPP_DIR does NOT have to be defined
for GenerateCLP to work.

cc: @jcfr 