### PR TITLE
BUG: Fix GenerateCLP_FORWARD_PATHS_[BUILD/INSTALL] variable

### DIFF
--- a/GenerateCLP/CMakeLists.txt
+++ b/GenerateCLP/CMakeLists.txt
@@ -164,22 +164,22 @@ if(JsonCpp_FOUND)
   get_filename_component(json_library_dir ${JsonCpp_LIBRARY} DIRECTORY)
   set(json_forward_path_build
      "\"${json_library_dir}\" CONFIG_DIR_POST, \\
-     \"${json_library_dir}\", \\"
+     \"${json_library_dir}\","
     )
-  set(json_forward_path_install "\"${json_library_dir}\", \\")
+  set(json_forward_path_install "\"${json_library_dir}\",")
 endif()
 
 set(GenerateCLP_FORWARD_DIR_BUILD "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 set(GenerateCLP_FORWARD_PATH_BUILD " \\
    \".\" CONFIG_DIR_POST, \\
    \"${ITK_DIR}/bin\" CONFIG_DIR_POST, \\
-   ${json_forward_path_build}
+   ${json_forward_path_build} \\
    \"${ModuleDescriptionParser_DIR}/bin\" CONFIG_DIR_POST \\
 ")
 set(GenerateCLP_FORWARD_PATH_INSTALL " \\
    \".\", \\
    \"${ITK_DIR}/bin\", \\
-   ${json_forward_path_install}
+   ${json_forward_path_install} \\
    \"${ModuleDescriptionParser_DIR}/bin\" \\
 ")
 set(GenerateCLP_FORWARD_EXE GenerateCLP)


### PR DESCRIPTION
The GenerateCLP_FORWARD_PATHS_BUILD and GenerateCLP_FORWARD_PATHS_INSTALL
variables are used to generate a C++ macro. In d58e6643f5c12f568da5861ba133ac3c4b4e05cb
a bug was introduced when SlicerExecutionModel is built without JSON
support, the macro is generated with an empty line, breaking compilation.

This commit fixes the GenerateCLP_FORWARD_PATHS_[BUILD/INSTALL] variables
to make sure the C++ macro are always valid.

See Issue #81 