### PR TITLE
ENH: GenerateCLP: Include jsoncpp include dirs in UseGenerateCLP.cmak…

### DIFF
--- a/GenerateCLP/UseGenerateCLP.cmake.in
+++ b/GenerateCLP/UseGenerateCLP.cmake.in
@@ -23,4 +23,12 @@ if(NOT ITK_FOUND) #Do not clobber existing found version of ITK
   set(ITK_FOUND FALSE)
 endif()
 
+#
+# JsonCpp
+#
+if(GenerateCLP_USE_JSONCPP)
+  find_package(JsonCpp REQUIRED)
+  include_directories(${JsonCpp_INCLUDE_DIR})
+endif()
+
 include(${GenerateCLP_CMAKE_DIR}/GenerateCLP.cmake)


### PR DESCRIPTION
…e.in

The jsoncpp include directories are not included when a user includes
the GenerateCLP_USE_FILE even though files in GenerateCLP may depend on it
(if GenerateCLP_USE_JSON is true).