### PR TITLE
BUG: ModuleDescription: Param LibraryLoader shadows this->LibraryLoader

### DIFF
--- a/ModuleDescriptionParser/ModuleDescription.cxx
+++ b/ModuleDescriptionParser/ModuleDescription.cxx
@@ -592,9 +592,9 @@ ModuleProcessInformation* ModuleDescription::GetProcessInformation()
 
 //----------------------------------------------------------------------------
 void ModuleDescription::
-SetTargetCallback(void* LibraryLoader, TargetCallbackType targetCallback)
+SetTargetCallback(void* libraryLoader, TargetCallbackType targetCallback)
 {
-  this->LibraryLoader = LibraryLoader;
+  this->LibraryLoader = libraryLoader;
   this->TargetCallback = targetCallback;
 }
 


### PR DESCRIPTION
SlicerExecutionModel/ModuleDescriptionParser/ModuleDescription.cxx:595:
warning: declaration shadows a field of 'ModuleDescription' [-Wshadow]
SetTargetCallback(void* LibraryLoader, TargetCallbackType
targetCallback)

SlicerExecutionModel/ModuleDescriptionParser/ModuleDescription.h:175:
note: previous declaration is here
void* LibraryLoader;

Changed function parameter to use lower case libraryLoader as is done
for other parameter passed to that function that also has a parallel
member variable