### PR TITLE
COMP: GenerateCLP: Fix -Wunused-variable warning

### DIFF
--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -675,7 +675,6 @@ void GenerateSerialization( std::ostream & sout,
          ++paramIt )
       {
       const std::string & parameterName = paramIt->GetName();
-      const std::string & cppType = paramIt->GetCPPType();
       w | "    parameterGroup[\"" + parameterName
            + "\"] = JsonSerialize( " + parameterName + " );";
       }


### PR DESCRIPTION
```
/path/to/SlicerExecutionModel/GenerateCLP/GenerateCLP.cxx:678:27: warning: unused variable 'cppType' [-Wunused-variable]
      const std::string & cppType = paramIt->GetCPPType();
                          ^
```