### PR TITLE
STYLE: Renaming of the 'defaultValue' parameter's attribute to 'Value'

### DIFF
--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -126,9 +126,9 @@ bool IsVectorOfVectors(const ModuleParameter &parameter)
   return (type == "std::vector<std::vector<float> >");
 }
 
-bool HasDefault(const ModuleParameter &parameter)
+bool HasValue(const ModuleParameter &parameter)
 {
-  return (parameter.GetDefault().size() > 0 && parameter.GetMultiple() != "true");
+  return (parameter.GetValue().size() > 0 && parameter.GetMultiple() != "true");
 }
 
 /* Generate the preamble to the code. This includes the required
@@ -332,7 +332,7 @@ main(int argc, char *argv[])
   parametersSerialize.SetName("parametersSerialize");
   parametersSerialize.SetLongFlag("serialize");
   parametersSerialize.SetDescription("Store the module's parameters to a file.");
-  parametersSerialize.SetDefault("");
+  parametersSerialize.SetValue("");
   parametersSerialize.SetChannel("output");
   serializationGroup.AddParameter(parametersSerialize);
 
@@ -1031,7 +1031,7 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
   echoSwitch.SetName("echoSwitch");
   echoSwitch.SetLongFlag("echo");
   echoSwitch.SetDescription("Echo the command line arguments");
-  echoSwitch.SetDefault("false");
+  echoSwitch.SetValue("false");
   autoParameters.AddParameter(echoSwitch);
 
   // Add a switch argument to produce xml output
@@ -1041,7 +1041,7 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
   xmlSwitch.SetName("xmlSwitch");
   xmlSwitch.SetLongFlag("xml");
   xmlSwitch.SetDescription("Produce xml description of command line arguments");
-  xmlSwitch.SetDefault("false");
+  xmlSwitch.SetValue("false");
   autoParameters.AddParameter(xmlSwitch);
 
   // Add an argument to accept an address for storing process
@@ -1052,7 +1052,7 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
   processInformationAddressArg.SetName("processInformationAddressString");
   processInformationAddressArg.SetLongFlag("processinformationaddress");
   processInformationAddressArg.SetDescription("Address of a structure to store process information (progress, abort, etc.).");
-  processInformationAddressArg.SetDefault("0");
+  processInformationAddressArg.SetValue("0");
   autoParameters.AddParameter(processInformationAddressArg);
 
   // Add an argument to accept a filename for simple return types
@@ -1062,7 +1062,7 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
   returnParameterArg.SetName("returnParameterFile");
   returnParameterArg.SetLongFlag("returnparameterfile");
   returnParameterArg.SetDescription("Filename in which to write simple return parameters (int, float, int-vector, etc.) as opposed to bulk return parameters (image, geometry, transform, measurement, table).");
-  returnParameterArg.SetDefault("");
+  returnParameterArg.SetValue("");
   autoParameters.AddParameter(returnParameterArg);
 
 
@@ -1077,7 +1077,7 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
   parametersDeSerialize.SetName("parametersDeSerialize");
   parametersDeSerialize.SetLongFlag("deserialize");
   parametersDeSerialize.SetDescription("Restore the module's parameters that were previously archived.");
-  parametersDeSerialize.SetDefault("");
+  parametersDeSerialize.SetValue("");
   parametersDeSerialize.SetChannel("input");
 
   // Find the serialization group and add to it.
@@ -1185,7 +1185,7 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
           }
         
         const std::string cppType = pit->GetCPPType();
-        if (!HasDefault(*pit) &&
+        if (!HasValue(*pit) &&
             cppType != "bool")
           {
           // Initialized to avoid compiler warnings.
@@ -1206,18 +1206,18 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
           }
         else
           {
-          std::string defaultString = pit->GetDefault();
+          std::string ValueString = pit->GetValue();
           if ((*pit).GetCPPType() == "bool")
             {
-            defaultString = "false";
+            ValueString = "false";
             }
-          replaceSubWithSub(defaultString, "\"", "\\\"");
+          replaceSubWithSub(ValueString, "\"", "\\\"");
           sout << " = ";
           if (NeedsQuotes(*pit))
             {
             sout << "\"";
             }
-          sout << defaultString;
+          sout << ValueString;
           if (NeedsQuotes(*pit))
             {
             sout << "\"";
@@ -1241,7 +1241,7 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
              << pit->GetCPPType()
              << " ";
         sout << pit->GetName();
-        if (!HasDefault(*pit))
+        if (!HasValue(*pit))
           {    
           sout << ";"
                << EOL << std::endl;
@@ -1253,13 +1253,13 @@ void GenerateDeclare(std::ostream &sout, ModuleDescription &module)
             {
             sout << "\"";
             }
-          std::string defaultString = pit->GetDefault();
+          std::string ValueString = pit->GetValue();
           if ((*pit).GetCPPType() == "bool")
             {
-            defaultString = "false";
+            ValueString = "false";
             }
-          replaceSubWithSub(defaultString, "\"", "\\\"");
-          sout << defaultString;
+          replaceSubWithSub(ValueString, "\"", "\\\"");
+          sout << ValueString;
           if (NeedsQuotes(*pit))
             {
             sout << "\"";
@@ -1352,24 +1352,24 @@ void GenerateTCLAPParse(std::ostream &sout, ModuleDescription &module)
       sout << "msg << "
            << "\""
            << pit->GetDescription();
-      if (pit->GetDefault().empty())
+      if (pit->GetValue().empty())
         {
         sout << "\";";
         }
       else
         {
-        sout << " (default: \" "
+        sout << " (value: \" "
              << "<< ";
-        if (HasDefault(*pit))
+        if (HasValue(*pit))
           {
-          sout << pit->GetName();
+          sout << pit->GetValue();
           }
         else
           {
           sout << "\"None\"";
           }
 
-        if (NeedsTemp(*pit) && HasDefault(*pit))
+        if (NeedsTemp(*pit) && HasValue(*pit))
           {
           sout << "Temp";
           }

--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -1362,7 +1362,7 @@ void GenerateTCLAPParse(std::ostream &sout, ModuleDescription &module)
              << "<< ";
         if (HasValue(*pit))
           {
-          sout << pit->GetValue();
+          sout << pit->GetName();
           }
         else
           {

--- a/ModuleDescriptionParser/BatchMakeUtilities.cxx
+++ b/ModuleDescriptionParser/BatchMakeUtilities.cxx
@@ -184,7 +184,7 @@ std::string GenerateBatchMakeWrapper(const ModuleDescription& module)
           wrapper << "</Name>" << std::endl;
           
           wrapper << indent4 << "<Value>";
-          wrapper << (*pit).GetDefault();
+          wrapper << (*pit).GetValue();
           wrapper << "</Value>" << std::endl;
 
           // The parent is the previous parameter (the parameter for
@@ -272,7 +272,7 @@ std::string GenerateBatchMakeWrapper(const ModuleDescription& module)
     wrapper << "</Name>" << std::endl;
     
     wrapper << indent4 << "<Value>";
-    wrapper << (*iit).second.GetDefault();
+    wrapper << (*iit).second.GetValue();
     wrapper << "</Value>" << std::endl;
     
     // index parameters have no parents

--- a/ModuleDescriptionParser/ModuleDescription.cxx
+++ b/ModuleDescriptionParser/ModuleDescription.cxx
@@ -183,7 +183,7 @@ bool ModuleDescription::HasReturnParameters() const
 
 //----------------------------------------------------------------------------
 std::vector<ModuleParameter> ModuleDescription
-::FindParametersWithDefaultValue(const std::string& defaultValue) const
+::FindParametersWithValue(const std::string& value) const
 {
   std::vector<ModuleParameter> parameters;
   // iterate over each parameter group
@@ -204,7 +204,7 @@ std::vector<ModuleParameter> ModuleDescription
 
     for (pit = pbeginit; pit != pendit; ++pit)
       {
-      if ((*pit).GetDefault() == defaultValue)
+      if ((*pit).GetValue() == value)
         {
         parameters.push_back(*pit);
         }
@@ -215,7 +215,7 @@ std::vector<ModuleParameter> ModuleDescription
 }
 
 //----------------------------------------------------------------------------
-bool ModuleDescription::SetParameterDefaultValue(const std::string& name, const std::string& value)
+bool ModuleDescription::SetParameterValue(const std::string& name, const std::string& value)
 {
   // iterate over each parameter group
   std::vector<ModuleParameterGroup>::iterator pgbeginit
@@ -237,7 +237,7 @@ bool ModuleDescription::SetParameterDefaultValue(const std::string& name, const 
       {
       if ((*pit).GetName() == name)
         {
-        (*pit).SetDefault(value);
+        (*pit).SetValue(value);
         return true;
         }
       }    
@@ -248,7 +248,7 @@ bool ModuleDescription::SetParameterDefaultValue(const std::string& name, const 
 
 
 //----------------------------------------------------------------------------
-std::string ModuleDescription::GetParameterDefaultValue(const std::string& name) const
+std::string ModuleDescription::GetParameterValue(const std::string& name) const
 {
   // iterate over each parameter group
   std::vector<ModuleParameterGroup>::const_iterator pgbeginit
@@ -270,7 +270,7 @@ std::string ModuleDescription::GetParameterDefaultValue(const std::string& name)
       {
       if ((*pit).GetName() == name)
         {
-        return (*pit).GetDefault();
+        return (*pit).GetValue();
         }
       }    
     }
@@ -326,9 +326,9 @@ bool ModuleDescription ::ReadParameterFile(const std::string& filename)
 
     if (this->HasParameter(key))
       {
-      if (value != this->GetParameterDefaultValue(key))
+      if (value != this->GetParameterValue(key))
         {
-        this->SetParameterDefaultValue(key, value);
+        this->SetParameterValue(key, value);
         modified = true;
 
         // multiple="true" may have to be handled differently
@@ -384,7 +384,7 @@ WriteParameterFile(const std::string& filename, bool withHandlesToBulkParameters
                   && (*pit).GetTag() != "region")))
         {
         rtp << (*pit).GetName() << " = " 
-            << (*pit).GetDefault() << std::endl;
+            << (*pit).GetValue() << std::endl;
 
         // multiple="true" may have to be handled differently
         }

--- a/ModuleDescriptionParser/ModuleDescription.cxx
+++ b/ModuleDescriptionParser/ModuleDescription.cxx
@@ -183,6 +183,14 @@ bool ModuleDescription::HasReturnParameters() const
 
 //----------------------------------------------------------------------------
 std::vector<ModuleParameter> ModuleDescription
+::FindParametersWithDefaultValue(const std::string& value) const
+{
+  return this->FindParametersWithValue(value);
+}
+
+
+//----------------------------------------------------------------------------
+std::vector<ModuleParameter> ModuleDescription
 ::FindParametersWithValue(const std::string& value) const
 {
   std::vector<ModuleParameter> parameters;
@@ -212,6 +220,12 @@ std::vector<ModuleParameter> ModuleDescription
     }
 
   return parameters;
+}
+
+//----------------------------------------------------------------------------
+bool ModuleDescription::SetParameterDefaultValue(const std::string& name, const std::string& value)
+{
+  return this->SetParameterValue( name, value);
 }
 
 //----------------------------------------------------------------------------
@@ -246,6 +260,11 @@ bool ModuleDescription::SetParameterValue(const std::string& name, const std::st
   return false;
 }
 
+//----------------------------------------------------------------------------
+std::string ModuleDescription::GetParameterDefaultValue(const std::string& name) const
+{
+  return this->GetParameterValue(name);
+}
 
 //----------------------------------------------------------------------------
 std::string ModuleDescription::GetParameterValue(const std::string& name) const

--- a/ModuleDescriptionParser/ModuleDescription.h
+++ b/ModuleDescriptionParser/ModuleDescription.h
@@ -100,11 +100,21 @@ public:
   /// \sa HasParameter()
   bool HasReturnParameters() const;
 
+  /// THIS FUNCTION SHOULD NOT BE USED
+  /// SEE FindParametersWithValue INSTEAD
+  std::vector<ModuleParameter> FindParametersWithDefaultValue(
+    const std::string& value)const;
+
   /// Search the list of parameters and return a copy of the parameters
   /// that have the same \a Value.
   /// \sa HasParameter(), HasReturnParameters(), GetParameterValue()
   std::vector<ModuleParameter> FindParametersWithValue(
     const std::string& value)const;
+
+  /// THIS FUNCTION SHOULD NOT BE USED
+  /// SEE SetParameterValue INSTEAD
+  bool SetParameterDefaultValue(const std::string& name,
+                         const std::string& value);
 
   /// Set the value of the parameter \a name.
   /// Return true if the parameter is found and different than \a value,
@@ -113,6 +123,10 @@ public:
   /// \sa FindParametersWithValue(), HasParameter()
   bool SetParameterValue(const std::string& name,
                          const std::string& value);
+
+  /// THIS FUNCTION SHOULD NOT BE USED
+  /// SEE GetParameterValue INSTEAD
+  std::string GetParameterDefaultValue(const std::string& name) const;
 
   /// Return the parameter value and an empty string if the parameter
   /// can not be found.

--- a/ModuleDescriptionParser/ModuleDescription.h
+++ b/ModuleDescriptionParser/ModuleDescription.h
@@ -101,23 +101,23 @@ public:
   bool HasReturnParameters() const;
 
   /// Search the list of parameters and return a copy of the parameters
-  /// that have the same \a defaultValue.
-  /// \sa HasParameter(), HasReturnParameters(), GetParameterDefaultValue()
-  std::vector<ModuleParameter> FindParametersWithDefaultValue(
-    const std::string& defaultvalue)const;
+  /// that have the same \a Value.
+  /// \sa HasParameter(), HasReturnParameters(), GetParameterValue()
+  std::vector<ModuleParameter> FindParametersWithValue(
+    const std::string& value)const;
 
-  /// Set the default value of the parameter \a name.
+  /// Set the value of the parameter \a name.
   /// Return true if the parameter is found and different than \a value,
   /// false otherwise.
-  /// \sa GetParameterDefaultValue(),
-  /// \sa FindParametersWithDefaultValue(), HasParameter()
-  bool SetParameterDefaultValue(const std::string& name,
-                                const std::string& value);
+  /// \sa GetParameterValue(),
+  /// \sa FindParametersWithValue(), HasParameter()
+  bool SetParameterValue(const std::string& name,
+                         const std::string& value);
 
-  /// Return the parameter default value and an empty string if the parameter
+  /// Return the parameter value and an empty string if the parameter
   /// can not be found.
-  /// \sa SetParameterDefaultValue()
-  std::string GetParameterDefaultValue(const std::string& name) const;
+  /// \sa SetParameterValue()
+  std::string GetParameterValue(const std::string& name) const;
 
   const ModuleProcessInformation* GetProcessInformation() const;
   ModuleProcessInformation* GetProcessInformation();

--- a/ModuleDescriptionParser/ModuleDescriptionParser.cxx
+++ b/ModuleDescriptionParser/ModuleDescriptionParser.cxx
@@ -2002,7 +2002,7 @@ endElement(void *userData, const char *element)
     {
     std::string temp = ps->LastData[ps->Depth];
     trimLeadingAndTrailing(temp);
-    parameter->SetDefault(temp);
+    parameter->SetValue(temp);
     }
   else if (parameter && (name == "channel"))
     {

--- a/ModuleDescriptionParser/ModuleParameter.cxx
+++ b/ModuleDescriptionParser/ModuleParameter.cxx
@@ -43,7 +43,7 @@ ModuleParameter::ModuleParameter()
     this->Hidden = "false";
     this->ArgType = "";
     this->StringToType = "";
-    this->Default = "";
+    this->Value = "";
     this->Flag = "";
     this->LongFlag = "";
     this->Constraints = "";
@@ -75,7 +75,7 @@ ModuleParameter::ModuleParameter(const ModuleParameter& parameter)
   this->Hidden = parameter.Hidden;
   this->ArgType = parameter.ArgType;
   this->StringToType = parameter.StringToType;
-  this->Default = parameter.Default;
+  this->Value = parameter.Value;
   this->Flag = parameter.Flag;
   this->FlagAliasesAsString = parameter.FlagAliasesAsString;
   this->FlagAliases = parameter.FlagAliases;
@@ -115,7 +115,7 @@ void ModuleParameter::operator=(const ModuleParameter& parameter)
   this->Hidden = parameter.Hidden;
   this->ArgType = parameter.ArgType;
   this->StringToType = parameter.StringToType;
-  this->Default = parameter.Default;
+  this->Value = parameter.Value;
   this->Flag = parameter.Flag;
   this->FlagAliasesAsString = parameter.FlagAliasesAsString;
   this->FlagAliases = parameter.FlagAliases;
@@ -208,7 +208,7 @@ std::ostream & operator<<(std::ostream &os, const ModuleParameter &parameter)
   os << "      " << "CPPType: " << parameter.GetCPPType() << std::endl;
   os << "      " << "ArgType: " << parameter.GetArgType() << std::endl;
   os << "      " << "StringToType: " << parameter.GetStringToType() << std::endl;
-  os << "      " << "Default: " << parameter.GetDefault() << std::endl;
+  os << "      " << "Value: " << parameter.GetValue() << std::endl;
   os << "      " << "Elements: ";
   std::vector<std::string>::const_iterator eit;  
   for (eit = parameter.GetElements().begin();

--- a/ModuleDescriptionParser/ModuleParameter.h
+++ b/ModuleDescriptionParser/ModuleParameter.h
@@ -25,7 +25,7 @@
  *
  * ModuleParameter describes a single parameters to a
  * module. Information on the parameter type, name, flag, label,
- * description, channel, index, default, and constraints can be
+ * description, channel, index, Value, and constraints can be
  * stored.
  *
  */
@@ -257,14 +257,14 @@ public:
     return this->Index;
   }
   
-  virtual void SetDefault(const std::string &def)
+  virtual void SetValue(const std::string &def)
   {
-    this->Default = def;
+    this->Value = def;
   }
 
-  virtual const std::string& GetDefault() const
+  virtual const std::string& GetValue() const
   {
-    return this->Default;
+    return this->Value;
   }
   
   virtual void SetFlag(const std::string &flag)
@@ -369,7 +369,7 @@ private:
   std::string Hidden;
   std::string ArgType;
   std::string StringToType;
-  std::string Default;
+  std::string Value;
   std::string Flag;
   std::string LongFlag;
   std::string Constraints;

--- a/ModuleDescriptionParser/ModuleParameter.h
+++ b/ModuleDescriptionParser/ModuleParameter.h
@@ -257,9 +257,23 @@ public:
     return this->Index;
   }
   
+  /// THIS FUNCTION SHOULD NOT BE USED
+  /// SEE SetValue INSTEAD
+  virtual void SetDefault(const std::string &def)
+  {
+    this->SetValue(def);
+  }
+
   virtual void SetValue(const std::string &def)
   {
     this->Value = def;
+  }
+
+  /// THIS FUNCTION SHOULD NOT BE USED
+  /// SEE GetValue INSTEAD
+  virtual const std::string& GetDefault() const
+  {
+    return this->GetValue();
   }
 
   virtual const std::string& GetValue() const

--- a/ModuleDescriptionParser/Testing/ModuleDescriptionTest.cxx
+++ b/ModuleDescriptionParser/Testing/ModuleDescriptionTest.cxx
@@ -8,7 +8,7 @@
 #include <string>
 
 //---------------------------------------------------------------------------
-int TestDefaults();
+int TestValues();
 int TestReadParameterFileWithMissingValue();
 int TestParameterFileWithPointFile();
 int TestTargetCallback();
@@ -30,7 +30,7 @@ int ModuleDescriptionTest(int argc, char * argv[])
 
   INPUT_DIR = std::string(argv[1]);
 
-  CHECK_EXIT_SUCCESS(TestDefaults());
+  CHECK_EXIT_SUCCESS(TestValues());
   CHECK_EXIT_SUCCESS(TestReadParameterFileWithMissingValue());
   CHECK_EXIT_SUCCESS(TestParameterFileWithPointFile());
   CHECK_EXIT_SUCCESS(TestTargetCallback());
@@ -39,7 +39,7 @@ int ModuleDescriptionTest(int argc, char * argv[])
 }
 
 //---------------------------------------------------------------------------
-int TestDefaults()
+int TestValues()
 {
   ModuleLogo logo;
   CHECK_INT(logo.GetWidth(),        0);
@@ -121,7 +121,7 @@ int TestReadParameterFileWithMissingValue()
     return EXIT_FAILURE;
     }
 
-  if (desc.GetParameterDefaultValue("OutputLabel") != "")
+  if (desc.GetParameterValue("OutputLabel") != "")
     {
     std::cerr << "Line " << __LINE__
               << " - Problem reading parameters - Value is expected to be empty."
@@ -129,7 +129,7 @@ int TestReadParameterFileWithMissingValue()
     return EXIT_FAILURE;
     }
 
-  if (desc.GetParameterDefaultValue("SUVMean") != "2")
+  if (desc.GetParameterValue("SUVMean") != "2")
     {
     std::cerr << "Line " << __LINE__
               << " - Problem reading parameters - Value is expected to be '2'."
@@ -151,7 +151,7 @@ int TestParameterFileWithPointFile()
   {
     ModuleParameter parameter;
     parameter.SetName("Input Fiducial File");
-    parameter.SetDefault("input.fcsv");
+    parameter.SetValue("input.fcsv");
     parameter.SetTag("pointfile");
     parameter.SetMultiple("false");
     parameter.SetFileExtensionsAsString(".fcsv");
@@ -163,7 +163,7 @@ int TestParameterFileWithPointFile()
   {
     ModuleParameter parameter;
     parameter.SetName("Output Fiducial File");
-    parameter.SetDefault("output.fcsv");
+    parameter.SetValue("output.fcsv");
     parameter.SetTag("pointfile");
     parameter.SetMultiple("false");
     parameter.SetFileExtensionsAsString(".fcsv");

--- a/ModuleDescriptionParser/itkSEMModuleParameterSerializer.cxx
+++ b/ModuleDescriptionParser/itkSEMModuleParameterSerializer.cxx
@@ -36,8 +36,8 @@ SEMModuleParameterSerializer
   this->m_Parameters["CoordinateSystem"] = m_CoordinateSystem;
   m_CPPType = new StringValue;
   this->m_Parameters["CPPType"] = m_CPPType;
-  m_Default = new StringValue;
-  this->m_Parameters["Default"] = m_Default;
+  m_Value = new StringValue;
+  this->m_Parameters["Value"] = m_Value;
   m_Description = new StringValue;
   this->m_Parameters["Description"] = m_Description;
   m_Flag = new StringValue;
@@ -73,7 +73,7 @@ SEMModuleParameterSerializer
   delete m_Channel;
   delete m_CPPType;
   delete m_CoordinateSystem;
-  delete m_Default;
+  delete m_Value;
   delete m_Description;
   delete m_Flag;
   delete m_Index;
@@ -110,8 +110,8 @@ SEMModuleParameterSerializer
     this->m_Parameters["CoordinateSystem"] = m_CoordinateSystem;
     m_CPPType->SetValue( parameter.GetCPPType() );
     this->m_Parameters["CPPType"] = m_CPPType;
-    m_Default->SetValue( parameter.GetDefault() );
-    this->m_Parameters["Default"] = m_Default;
+    m_Value->SetValue( parameter.GetValue() );
+    this->m_Parameters["Value"] = m_Value;
     m_Description->SetValue( parameter.GetDescription() );
     this->m_Parameters["Description"] = m_Description;
     m_Flag->SetValue( parameter.GetFlag() );
@@ -159,7 +159,7 @@ SEMModuleParameterSerializer
     parameter.SetChannel( this->m_Channel->GetValue() );
     parameter.SetCPPType( this->m_CPPType->GetValue() );
     parameter.SetCoordinateSystem( this->m_CoordinateSystem->GetValue() );
-    parameter.SetDefault( this->m_Default->GetValue() );
+    parameter.SetValue( this->m_Value->GetValue() );
     parameter.SetDescription( this->m_Description->GetValue() );
     parameter.SetFlag( this->m_Flag->GetValue() );
     parameter.SetIndex( this->m_Index->GetValue() );

--- a/ModuleDescriptionParser/itkSEMModuleParameterSerializer.h
+++ b/ModuleDescriptionParser/itkSEMModuleParameterSerializer.h
@@ -109,7 +109,7 @@ protected:
   StringValue *      m_Channel;
   StringValue *      m_CoordinateSystem;
   StringValue *      m_CPPType;
-  StringValue *      m_Default;
+  StringValue *      m_Value;
   StringValue *      m_Description;
   StringValue *      m_Flag;
   StringValue *      m_Index;


### PR DESCRIPTION
This attribute (declared in [moduleParameter](https://github.com/Slicer/SlicerExecutionModel/compare/master...jbvimort:defaultValueNamingImprovement?expand=1#diff-2c64a747d4f10af24e65281fb99947d0L372) ) is first used to store the default value specified in the xml file, but it is then used to store the value specified by the user through the user interface or the result computed by the CLI.

Renaming the attribute from 'default' to 'value' as well as all the get/set functions related seems to make more sense.

Some modifications will also be necessary in Slicer, particularly in the part managing the CLIs (like [here](https://github.com/Slicer/Slicer/blob/9e7de7256691782a2650a312313d47aafa31c4a2/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx#L290) for example).

For the different extensions of Slicer that are accessing the CLI's parameter values thanks to GetDefaultParameter(), a possible solution that would avoid to modify all the extensions would be to keep old functions (like [this one](https://github.com/Slicer/Slicer/blob/9e7de7256691782a2650a312313d47aafa31c4a2/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx#L938-L945), that actually give the current value of the parameter) and depreciate them, and create new ones with names more meaningful.