### PR TITLE
Makefile: Ensure image is deleted if different

### DIFF
--- a/test/Docker/Makefile
+++ b/test/Docker/Makefile
@@ -5,7 +5,7 @@
 # Name of the docker executable
 DOCKER = docker
 
-# DockerHub organization and repository to pull the images from
+# DockerHub organization and repository to pull/push the images from/to
 ORG = slicer
 REPO = slicerexecutionmodel
 
@@ -48,7 +48,8 @@ $(DIRECTORIES): %: ../%/Dockerfile
 	  --build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		../$@
-	if [ -n "$(IMAGEID)" ]; then $(DOCKER) rmi "$(IMAGEID)"; fi
+	CURRENT_IMAGEID=$$($(DOCKER) images -q $(ORG)/$(REPO)) && \
+	if [ -n "$(IMAGEID)" ] && [ "$(IMAGEID)" != "$$CURRENT_IMAGEID" ]; then $(DOCKER) rmi "$(IMAGEID)"; fi
 
 #
 # run implicit rule


### PR DESCRIPTION
Since BUILD_DATE is always different, the image is already ensured
to be different. This comment is done to have consistent makefile and
follow the best practice.