### PR TITLE
BUG: Fix compilation when policies are less than 3.13.0

### DIFF
--- a/CMake/SEMMacroBuildCLI.cmake
+++ b/CMake/SEMMacroBuildCLI.cmake
@@ -205,15 +205,19 @@ macro(SEMMacroBuildCLI)
 
   # Enable Interprocedural / global link-time optimization, if supported
   if(CMAKE_VERSION VERSION_GREATER 3.13.0 OR CMAKE_VERSION VERSION_EQUAL 3.13.0)
-    # Optional IPO. Do not use IPO if it's not supported by compiler.
-    include(CheckIPOSupported)
-    check_ipo_supported(RESULT result OUTPUT output)
-    if(result)
-      set_target_properties(${cli_targets} PROPERTIES
-        INTERPROCEDURAL_OPTIMIZATION TRUE
-        )
-    else()
-      message(WARNING "IPO is not supported: ${output}")
+    cmake_policy(GET CMP0069 REQUIRED_CMP0069_SETTING)
+    ## CheckIPOSupported fails if policy CMP0069 is not set to new
+    if( "${REQUIRED_CMP0069_SETTING}" EQUAL "NEW" )
+      # Optional IPO. Do not use IPO if it's not supported by compiler.
+      include(CheckIPOSupported)
+      check_ipo_supported(RESULT result OUTPUT output)
+      if(result)
+        set_target_properties(${cli_targets} PROPERTIES
+          INTERPROCEDURAL_OPTIMIZATION TRUE
+          )
+      else()
+        message(WARNING "IPO is not supported: ${output}")
+      endif()
     endif()
   endif()
 


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/module/CheckIPOSupported.html?highlight=s

It makes no sense to use the CheckIPOSupported module when CMP0069 is set to OLD so
module will return error in this case. See policy CMP0069 for details.

Building external SEM tools (i.e. UKFTractography) which has
cmake_required_version(3.5) fails when building with cmake 3.13.0
because the default policy is set cmake 3.5 features (i.e. CMP0069 is
OFF).

CMake Error at
/Users/johnsonhj/local/cmake-3.13.0-Linux-x86_64/share/cmake-3.13/Modules/CheckIPOSupported.cmake:145
(message):
  Policy CMP0069 is not set
Call Stack (most recent call first):
  /localscratch/Users/johnsonhj/NEP-11/SlicerExecutionModel-build/CMake/SEMMacroBuildCLI.cmake:210
(check_ipo_supported)
  UKFTractography/CMakeLists.txt:24 (SEMMacroBuildCLI)
-- Configuring incomplete, errors occurred!