### PR TITLE
COMP: Replace obsolete add_compiler_export_flags

### DIFF
--- a/ModuleDescriptionParser/CMakeLists.txt
+++ b/ModuleDescriptionParser/CMakeLists.txt
@@ -151,7 +151,6 @@ endif()
 # --------------------------------------------------------------------------
 set(lib_name ModuleDescriptionParser)
 include(GenerateExportHeader)
-add_compiler_export_flags()
 add_library(${lib_name} ${ModuleDescriptionParser_SRCS})
 generate_export_header(${lib_name}
   BASE_NAME ${lib_name}
@@ -181,6 +180,14 @@ endif()
 
 target_link_libraries(${lib_name} ${libs})
 ## target_link_libraries(${lib_name}-static ${link_libs})
+
+option(USE_COMPILER_HIDDEN_VISIBILITY "Use HIDDEN visibility support if available." ON)
+mark_as_advanced(USE_COMPILER_HIDDEN_VISIBILITY)
+if(USE_COMPILER_HIDDEN_VISIBILITY)
+  set_target_properties(${lib_name} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  set_target_properties(${lib_name} PROPERTIES C_VISIBILITY_PRESET hidden)
+  set_target_properties(${lib_name} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+endif()
 
 #
 # Apply user-defined properties to the library target.


### PR DESCRIPTION
 CMake Deprecation Warning at
 share/cmake/Modules/GenerateExportHeader.cmake:414 (message):
   The add_compiler_export_flags function is obsolete.  Use the
   CXX_VISIBILITY_PRESET and VISIBILITY_INLINES_HIDDEN target properties
   instead.
 Call Stack (most recent call first):
   ModuleDescriptionParser/CMakeLists.txt:154 (add_compiler_export_flags)

Resolves #102