### PR TITLE
ENH: Add forward reference support

### DIFF
--- a/ModuleDescriptionParser/ModuleDescriptionParser.cxx
+++ b/ModuleDescriptionParser/ModuleDescriptionParser.cxx
@@ -929,7 +929,7 @@ startElement(void *userData, const char *element, const char **attrs)
       }
     parameter = new ModuleParameter;
     int attrCount = XML_GetSpecifiedAttributeCount(ps->Parser);
-    if (attrCount == 2 && 
+    if (attrCount == 2 &&
         (strcmp(attrs[0], "multiple") == 0) &&
         (strcmp(attrs[1], "true") == 0))
       {
@@ -1544,6 +1544,27 @@ startElement(void *userData, const char *element, const char **attrs)
         }
       }
     }
+  else if (parameter && (name == "reference"))
+    {
+    int attrCount = XML_GetSpecifiedAttributeCount(ps->Parser);
+    if (attrCount > 0)
+      {
+      std::string role("");
+      std::string parameterName("");
+      for (int i=0; i < attrCount/2; ++i)
+        {
+        if (strcmp(attrs[2*i], "role") == 0)
+          {
+          role = std::string(attrs[2*i+1]);
+          }
+        else if (strcmp(attrs[2*i], "parameter") == 0)
+          {
+          parameterName = std::string(attrs[2*i+1]);
+          }
+        }
+      parameter->AddForwardReference(role, parameterName);
+      }
+    }
   ps->CurrentParameter = parameter;
   ps->CurrentGroup = group;
   ps->OpenTags.push(name);
@@ -1790,7 +1811,7 @@ endElement(void *userData, const char *element)
       {
       std::string error("ModuleDescriptionParser Error: <"
                         + name
-                        + std::string("> can only contain one character. \"") 
+                        + std::string("> can only contain one character. \"")
                         + temp
                         + std::string("\" has more than one character."));
       if (ps->ErrorDescription.size() == 0)
@@ -1848,12 +1869,12 @@ endElement(void *userData, const char *element)
         ps->ErrorLine = XML_GetCurrentLineNumber(ps->Parser);
         ps->Error = true;
         }
-        if (!ps->OpenTags.empty())
-          {
-          ps->OpenTags.pop();
-          ps->Depth--;
-          }
-        return;
+      if (!ps->OpenTags.empty())
+        {
+        ps->OpenTags.pop();
+        ps->Depth--;
+        }
+      return;
       }
     if (!parameter->GetIndex().empty())
       {
@@ -1867,11 +1888,11 @@ endElement(void *userData, const char *element)
         ps->ErrorLine = XML_GetCurrentLineNumber(ps->Parser);
         ps->Error = true;
         }
-        if (!ps->OpenTags.empty())
-          {
-          ps->OpenTags.pop();
-          ps->Depth--;
-          }
+      if (!ps->OpenTags.empty())
+        {
+        ps->OpenTags.pop();
+        ps->Depth--;
+        }
       return;
       }
     parameter->SetLongFlag(temp);
@@ -2057,7 +2078,11 @@ endElement(void *userData, const char *element)
     trimLeadingAndTrailing(temp);
     parameter->SetStep(temp);
     }
-  else if(name != "executable")
+  else if (parameter && (name == "reference"))
+    {
+    // No-op: merely make "reference" element accepted. Its contents are handled in startElement
+    }
+  else if (name != "executable")
     {
     std::string error("ModuleDescriptionParser Error: Unrecognized element <" + name + std::string("> was found."));
     if (ps->ErrorDescription.size() == 0)
@@ -2066,7 +2091,7 @@ endElement(void *userData, const char *element)
       ps->ErrorLine = XML_GetCurrentLineNumber(ps->Parser);
       ps->Error = true;
       }
-    } 
+    }
 
   if (!ps->OpenTags.empty())
     {
@@ -2096,7 +2121,7 @@ ModuleDescriptionParser::processHiddenAttribute(const char* value, ModuleParamet
       }
     return false;
     }
-} 
+}
 
 //----------------------------------------------------------------------------
 void
@@ -2125,7 +2150,7 @@ ModuleDescriptionParser::Parse( const std::string& xml, ModuleDescription& descr
 
   ParserState parserState;
   parserState.CurrentDescription = description;
-  
+
   XML_Parser parser = XML_ParserCreate(NULL);
   int done;
 

--- a/ModuleDescriptionParser/ModuleParameter.cxx
+++ b/ModuleDescriptionParser/ModuleParameter.cxx
@@ -33,33 +33,33 @@ splitString (const std::string &text,
 //----------------------------------------------------------------------------
 ModuleParameter::ModuleParameter()
 {
-    this->Tag = "";
-    this->Name = "";
-    this->Description = "";
-    this->Label = "";
-    this->CPPType = "";
-    this->Type = "";
-    this->Reference = "";
-    this->Hidden = "false";
-    this->ArgType = "";
-    this->StringToType = "";
-    this->Value = "";
-    this->Flag = "";
-    this->LongFlag = "";
-    this->Constraints = "";
-    this->Minimum = "";
-    this->Maximum = "";
-    this->Step = "";
-    this->Channel = "";
-    this->Index = "";
-    this->Multiple = "false";
-    this->Aggregate = "false";
-    this->FileExtensionsAsString = "";        
-    this->CoordinateSystem = "";
-    this->FlagAliasesAsString = "";
-    this->DeprecatedFlagAliasesAsString = "";
-    this->LongFlagAliasesAsString = "";
-    this->DeprecatedLongFlagAliasesAsString = "";
+  this->Tag = "";
+  this->Name = "";
+  this->Description = "";
+  this->Label = "";
+  this->CPPType = "";
+  this->Type = "";
+  this->Reference = "";
+  this->Hidden = "false";
+  this->ArgType = "";
+  this->StringToType = "";
+  this->Value = "";
+  this->Flag = "";
+  this->LongFlag = "";
+  this->Constraints = "";
+  this->Minimum = "";
+  this->Maximum = "";
+  this->Step = "";
+  this->Channel = "";
+  this->Index = "";
+  this->Multiple = "false";
+  this->Aggregate = "false";
+  this->FileExtensionsAsString = "";        
+  this->CoordinateSystem = "";
+  this->FlagAliasesAsString = "";
+  this->DeprecatedFlagAliasesAsString = "";
+  this->LongFlagAliasesAsString = "";
+  this->DeprecatedLongFlagAliasesAsString = "";
 }
 
 //----------------------------------------------------------------------------
@@ -72,6 +72,7 @@ ModuleParameter::ModuleParameter(const ModuleParameter& parameter)
   this->CPPType = parameter.CPPType;
   this->Type = parameter.Type;
   this->Reference = parameter.Reference;
+  this->ForwardReferences = parameter.ForwardReferences;
   this->Hidden = parameter.Hidden;
   this->ArgType = parameter.ArgType;
   this->StringToType = parameter.StringToType;
@@ -112,6 +113,7 @@ void ModuleParameter::operator=(const ModuleParameter& parameter)
   this->CPPType = parameter.CPPType;
   this->Type = parameter.Type;
   this->Reference = parameter.Reference;
+  this->ForwardReferences = parameter.ForwardReferences;
   this->Hidden = parameter.Hidden;
   this->ArgType = parameter.ArgType;
   this->StringToType = parameter.StringToType;
@@ -204,6 +206,28 @@ std::ostream & operator<<(std::ostream &os, const ModuleParameter &parameter)
   os << "      " << "Label: " << parameter.GetLabel() << std::endl;
   os << "      " << "Type: " << parameter.GetType() << std::endl;
   os << "      " << "Reference: " << parameter.GetReference() << std::endl;
+  std::map<std::string,std::vector<std::string> > forwardReferences;
+  parameter.GetForwardReferences(forwardReferences);
+  std::map<std::string,std::vector<std::string> >::const_iterator frit;
+  for (frit = forwardReferences.begin(); frit != forwardReferences.end(); ++frit)
+    {
+    if (frit != forwardReferences.begin())
+      {
+      os << "; ";
+      }
+    os << frit->first << ": ";
+
+    std::vector<std::string>::const_iterator frvit;
+    for (frvit = frit->second.begin(); frvit != frit->second.end(); ++frvit)
+      {
+      if (frvit != frit->second.begin())
+        {
+        os << ", ";
+        }
+      os << (*frvit);
+      }
+    }
+  os << std::endl;
   os << "      " << "Hidden: " << parameter.GetHidden() << std::endl;
   os << "      " << "CPPType: " << parameter.GetCPPType() << std::endl;
   os << "      " << "ArgType: " << parameter.GetArgType() << std::endl;

--- a/ModuleDescriptionParser/ModuleParameter.h
+++ b/ModuleDescriptionParser/ModuleParameter.h
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <map>
 
 /** \class ModuleParameter
  *  \brief Class to describe a single parameter to a module.
@@ -76,6 +77,27 @@ public:
   virtual const std::string& GetReference() const
   {
     return this->Reference;
+  }
+
+  virtual void AddForwardReference(const std::string &role, const std::string &ref)
+  {
+    std::map<std::string,std::vector<std::string> >::iterator frit =
+      this->ForwardReferences.find(role);
+    if (frit != this->ForwardReferences.end())
+      {
+      this->ForwardReferences[role].push_back(ref);
+      }
+    else
+      {
+      std::vector<std::string> refVector(1, ref);
+      this->ForwardReferences[role] = refVector;
+      }
+  }
+
+  virtual const void GetForwardReferences(
+    std::map<std::string,std::vector<std::string> > &refs) const
+  {
+    refs = this->ForwardReferences;
   }
 
   virtual void SetHidden(const std::string &hidden)
@@ -380,6 +402,7 @@ private:
   std::string CPPType;
   std::string Type;
   std::string Reference;
+  std::map<std::string,std::vector<std::string> > ForwardReferences;
   std::string Hidden;
   std::string ArgType;
   std::string StringToType;


### PR DESCRIPTION
It was possible to define references before, but they have special meaning (set parent transform, etc), and they are defined "in reverse", i.e. in the referenced object.
This change adds support for generic, forward references, which allow specifying any type of reference between two nodes. For example in a registration module, the output transform can specify node references to the moving and fixed images.

An example element (under a parameter element) is:
```
  <reference role="spatialRegistrationMoving" parameter="movingVolume"/>
```