### PR TITLE
COMP: Fix compilation warning

### DIFF
--- a/ModuleDescriptionParser/ModuleParameter.h
+++ b/ModuleDescriptionParser/ModuleParameter.h
@@ -94,7 +94,7 @@ public:
       }
   }
 
-  virtual const void GetForwardReferences(
+  virtual void GetForwardReferences(
     std::map<std::string,std::vector<std::string> > &refs) const
   {
     refs = this->ForwardReferences;


### PR DESCRIPTION
SlicerExecutionModel/ModuleDescriptionParser/ModuleParameter.h:97:11: warning:
      'const' type qualifier on return type has no effect [-Wignored-qualifiers]
  virtual const void GetForwardReferences(
          ^~~~~~
1 warning generated.