### PR TITLE
COMP: Protect from redefinition warnings

### DIFF
--- a/tclap/include/tclap/ValuesConstraint.h
+++ b/tclap/include/tclap/ValuesConstraint.h
@@ -30,7 +30,9 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #else
+#ifndef HAVE_SSTREAM //This may have been defined elsewhere
 #define HAVE_SSTREAM
+#endif
 #endif
 
 #if defined(HAVE_SSTREAM)


### PR DESCRIPTION
Both SlicerExecutionModel and DCMTK find and define
define HAVE_SSTREAM variable.    Protect the definition
of HAVE_SSTREAM when it is already defined.