### PR TITLE
Improve shortlist formatting

### DIFF
--- a/tclap/include/tclap/StdOutput.h
+++ b/tclap/include/tclap/StdOutput.h
@@ -164,30 +164,36 @@ inline void StdOutput::_shortUsage( CmdLineInterface& _cmd,
   XorHandler xorHandler = _cmd.getXorHandler();
   std::vector< std::vector<Arg*> > xorList = xorHandler.getXorList();
 
-  std::string s = progName + " ";
+  std::string s = progName;
 
+  spacePrint( std::cout, s, 75, 2, 6 );
+  s.clear();
+  const int secondLineOffset = 4;
   // first the xor
   for ( int i = 0; static_cast<unsigned int>(i) < xorList.size(); i++ )
     {
     s += " {";
     for ( ArgVectorIterator it = xorList[i].begin();
           it != xorList[i].end(); it++ )
+      {
       s += (*it)->shortID() + "|";
+      }
 
     s[s.length()-1] = '}';
+    spacePrint( std::cout, s, 75, secondLineOffset, 3*secondLineOffset );
+    s.clear();
     }
 
   // then the rest
   for (ArgListIterator it = argList.begin(); it != argList.end(); it++)
+    {
     if ( !xorHandler.contains( (*it) ) )
+      {
       s += " " + (*it)->shortID();
-
-  // if the program name is too long, then adjust the second line offset
-  int secondLineOffset = static_cast<int>(progName.length()) + 2;
-  if ( secondLineOffset > 75/2 )
-    secondLineOffset = static_cast<int>(75/2);
-
-  spacePrint( std::cout, s, 75, 3, secondLineOffset );
+      }
+    spacePrint( std::cout, s, 75, secondLineOffset, 3*secondLineOffset );
+    s.clear();
+    }
 }
 
 inline void StdOutput::_longUsage( CmdLineInterface& _cmd,


### PR DESCRIPTION
Make line breaks to more easily read the short listing of command line options
in one condensed setting. The previous line breaking produced a format that
was hard to parse, read, and copy for understanding command line options.

OLD (21 lines):
```
   /Users/johnsonhj/src/BT-11/bin/BRAINSLandmarkInitializer
                                        [--returnparameterfile
                                        <std::string>]
                                        [--processinformationaddress
                                        <std::string>] [--xml] [--echo]
                                        [--bsplineNumberOfControlPoints
                                        <int>]
                                        [--inputReferenceImageFilename
                                        <std::string>]
                                        [--outputTransformType
                                        <AffineTransform|BSplineTransform
                                        |VersorRigid3DTransform>]
                                        [--outputTransformFilename
                                        <std::string>]
                                        [--inputWeightFilename
                                        <std::string>]
                                        [--inputMovingLandmarkFilename
                                        <std::string>]
                                        [--inputFixedLandmarkFilename
                                        <std::string>] [--] [--version]
                                        [-h]

```

NEW (16 lines):
```
    /Users/johnsonhj/src/BT-11/bin/BRAINSLandmarkInitializer
     [--returnparameterfile <std::string>]
     [--processinformationaddress <std::string>]
     [--xml]
     [--echo]
     [--bsplineNumberOfControlPoints <int>]
     [--inputReferenceImageFilename <std::string>]
     [--outputTransformType <AffineTransform|BSplineTransform
                |VersorRigid3DTransform>]
     [--outputTransformFilename <std::string>]
     [--inputWeightFilename <std::string>]
     [--inputMovingLandmarkFilename <std::string>]
     [--inputFixedLandmarkFilename <std::string>]
     [--]
     [--version]
     [-h]
```
