### PR TITLE
COMP: Fix VC++ C4251 warnings: needs to have dll-interface to be used by clients

### DIFF
--- a/ModuleDescriptionParser/CMakeLists.txt
+++ b/ModuleDescriptionParser/CMakeLists.txt
@@ -151,12 +151,14 @@ endif()
 # --------------------------------------------------------------------------
 set(lib_name ModuleDescriptionParser)
 include(GenerateExportHeader)
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/ModuleDescriptionParserPragmas.h.in ModuleDescriptionParser_PRAGMAS)
 add_library(${lib_name} ${ModuleDescriptionParser_SRCS})
 generate_export_header(${lib_name}
   BASE_NAME ${lib_name}
   EXPORT_MACRO_NAME ${lib_name}_EXPORT
   EXPORT_FILE_NAME ${lib_name}Export.h
   STATIC_DEFINE ${lib_name}_STATIC
+  CUSTOM_CONTENT_FROM_VARIABLE ModuleDescriptionParser_PRAGMAS
   )
 
 ## Always build an explicitly static library for linking against GenerateCLP so that

--- a/ModuleDescriptionParser/ModuleDescriptionParserPragmas.h.in
+++ b/ModuleDescriptionParser/ModuleDescriptionParserPragmas.h.in
@@ -1,0 +1,15 @@
+
+//-----------------------------------------------------------------------------
+// Content read from ModuleDescriptionParserPragmas.h.in and added by
+// passing CUSTOM_CONTENT_FROM_VARIABLE parameter associated with the
+// generate_export_header() CMake function.
+
+/** Disable some common warnings in MS VC++ */
+#if defined( _MSC_VER )
+
+// 'identifier' : class 'type' needs to have dll-interface to be used by
+// clients of class 'type2'
+#pragma warning ( disable : 4251 )
+
+#endif
+//-----------------------------------------------------------------------------


### PR DESCRIPTION
Since the same compiler is used to compile both the components of this project
and the "client" project, this is a non issue.

See https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=vs-2019