### PR TITLE
Add optional "type" attribute to "pointfile" element

### DIFF
--- a/ModuleDescriptionParser/ModuleDescription.xsd
+++ b/ModuleDescriptionParser/ModuleDescription.xsd
@@ -31,7 +31,7 @@
         <xsd:element name="string" type="paramType"/>
         <xsd:element name="string-vector" type="paramType"/>
         <xsd:element name="point" type="pointType"/>
-        <xsd:element name="pointfile" type="pointType"/>
+        <xsd:element name="pointfile" type="typedPointType"/>
         <xsd:element name="point-vector" type="pointType"/>
         <xsd:element name="region" type="pointType"/>
         <xsd:element name="region-vector" type="pointType"/>
@@ -78,11 +78,20 @@
           <xsd:attribute name="coordinateSystem">
             <xsd:simpleType>
               <xsd:restriction base="xsd:string">
-                <xsd:enumeration value="RAS"/>
-                <xsd:enumeration value="IJK"/>
+                <xsd:enumeration value="lps"/>
+                <xsd:enumeration value="ras"/>
+                <xsd:enumeration value="ijk"/>
               </xsd:restriction>
             </xsd:simpleType>
           </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="typedPointType" >
+      <xsd:complexContent>
+        <xsd:extension base="pointType">
+          <xsd:attribute name="type" type="xsd:string"/>
         </xsd:extension>
       </xsd:complexContent>
     </xsd:complexType>

--- a/ModuleDescriptionParser/ModuleDescriptionParser.cxx
+++ b/ModuleDescriptionParser/ModuleDescriptionParser.cxx
@@ -545,7 +545,7 @@ startElement(void *userData, const char *element, const char **attrs)
 
     // Parse attribute pairs
     parameter->SetCPPType("std::string");
-    parameter->SetType("scalar");
+    parameter->SetType("point");
     for (int attr=0; attr < (attrCount / 2); attr++)
       {
       if ((strcmp(attrs[2*attr], "multiple") == 0))
@@ -563,6 +563,31 @@ startElement(void *userData, const char *element, const char **attrs)
         else
           {
           std::string error("ModuleDescriptionParser Error: \"" + std::string(attrs[2*attr+1]) + "\" is not a valid argument for the attribute \"multiple\". Only \"true\" and \"false\" are accepted.");
+          if (ps->ErrorDescription.size() == 0)
+            {
+            ps->ErrorDescription = error;
+            ps->ErrorLine = XML_GetCurrentLineNumber(ps->Parser);
+            ps->Error = true;
+            }
+          ps->OpenTags.push(name);
+          delete parameter;
+          return;
+          }
+        }
+      else if ((strcmp(attrs[2*attr], "type") == 0))
+        {
+        if ((strcmp(attrs[2*attr+1], "any") == 0) ||
+            (strcmp(attrs[2*attr+1], "point") == 0) ||
+            (strcmp(attrs[2*attr+1], "line") == 0) ||
+            (strcmp(attrs[2*attr+1], "angle") == 0) ||
+            (strcmp(attrs[2*attr+1], "curve") == 0) ||
+            (strcmp(attrs[2*attr+1], "closedcurve")) )
+          {
+          parameter->SetType(attrs[2*attr+1]);
+          }
+        else
+          {
+          std::string error("ModuleDescriptionParser Error: \"" + std::string(attrs[2*attr+1]) + "\" is not a valid value for the attribute \"" + "type" + "\". Only \"point\", \"line\" , \"angle\", \"curve\", \"closedcurve\", and \"any\" are accepted.");
           if (ps->ErrorDescription.size() == 0)
             {
             ps->ErrorDescription = error;


### PR DESCRIPTION
This allows specifying that point list should be interpreted as line, angle, curve, or closed curve.

xsd file does not constrain the type (the same way as for image, geometry, etc.).