### PR TITLE
ENH: Update docker base image to include newer cmake version.

### DIFF
--- a/test/Docker-ITK-master_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
+++ b/test/Docker-ITK-master_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
@@ -1,10 +1,10 @@
-FROM dockbuild/centos5
+FROM dockbuild/centos7
 MAINTAINER Insight Software Consortium <community@itk.org>
 
 WORKDIR /usr/src
 
-# March 21, 2018
-ENV ITK_GIT_COMMIT 6953e199404bf7feb9534d5b58111267be90c963
+# March 15, 2020
+ENV ITK_GIT_COMMIT d67ae984a703a71b2d8d6932216561157b322c28
 
 RUN \
   #

--- a/test/Docker-ITK-v4.10.1_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
+++ b/test/Docker-ITK-v4.10.1_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockbuild/centos5
+FROM dockbuild/centos7
 MAINTAINER Insight Software Consortium <community@itk.org>
 
 WORKDIR /usr/src

--- a/test/Docker-ITK-v4.13.0_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
+++ b/test/Docker-ITK-v4.13.0_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockbuild/centos5
+FROM dockbuild/centos7
 MAINTAINER Insight Software Consortium <community@itk.org>
 
 WORKDIR /usr/src

--- a/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
+++ b/test/Docker-ITK-v4.8.0_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockbuild/centos5
+FROM dockbuild/centos7
 MAINTAINER Insight Software Consortium <community@itk.org>
 
 WORKDIR /usr/src


### PR DESCRIPTION
A newer cmake version is necessary for building
SlicerExecutionModel. These images are needed
for CI to pass.