### PR TITLE
COMP: Do not link ModuleDescriptionParser with entire ITK

### DIFF
--- a/ModuleDescriptionParser/CMakeLists.txt
+++ b/ModuleDescriptionParser/CMakeLists.txt
@@ -16,21 +16,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # --------------------------------------------------------------------------
-# Prerequisites
-# --------------------------------------------------------------------------
-
-#
-# ITK
-#
-set(${PROJECT_NAME}_ITK_COMPONENTS
-  ITKCommon# For itksys
-  ITKIOXML # For ITKEXPAT
-  ITKExpat # For Expat library
-  )
-find_package(ITK 4.3 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-include(${ITK_USE_FILE})
-
-# --------------------------------------------------------------------------
 # Option(s)
 # --------------------------------------------------------------------------
 if(NOT DEFINED BUILD_SHARED_LIBS)
@@ -45,6 +30,22 @@ if(ModuleDescriptionParser_USE_SERIALIZER)
   find_package(ParameterSerializer REQUIRED)
   include_directories(${ParameterSerializer_INCLUDE_DIRS})
 endif()
+
+# --------------------------------------------------------------------------
+# Prerequisites
+# --------------------------------------------------------------------------
+
+#
+# ITK
+#
+set(${PROJECT_NAME}_ITK_COMPONENTS
+  ITKCommon# For itksys
+  ITKIOXML # For ITKEXPAT
+  ITKExpat # For Expat library
+  )
+
+find_package(ITK 4.3 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
+include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------
 # Testing


### PR DESCRIPTION
find_package(ParameterSerializer) may do a find_package(ITK) that may
changes ITK_LIBRARIES used to target_link_libraries.

See https://github.com/InsightSoftwareConsortium/ITK/issues/1892