### PR TITLE
COMP: Do not force JsonCpp and ParameterSerializer DIR variable to empty string

### DIFF
--- a/GenerateCLP/GenerateCLPConfig.cmake.in
+++ b/GenerateCLP/GenerateCLPConfig.cmake.in
@@ -12,9 +12,21 @@ set(SlicerExecutionModel_CMAKE_DIR "@SlicerExecutionModel_CMAKE_DIR@")
 set(TCLAP_DIR "@TCLAP_DIR@")
 set(ModuleDescriptionParser_DIR "@ModuleDescriptionParser_DIR@")
 set(ITK_DIR "@ITK_DIR_CONFIG@")
-set(JsonCpp_INCLUDE_DIR "@JsonCpp_INCLUDE_DIR@")
-set(JsonCpp_LIBRARY "@JsonCpp_LIBRARY@")
-set(ParameterSerializer_DIR "@ParameterSerializer_DIR@")
+
+set(GenerateCLP_JsonCpp_INCLUDE_DIR "@JsonCpp_INCLUDE_DIR@")
+if(NOT "${GenerateCLP_JsonCpp_INCLUDE_DIR}" STREQUAL "")
+  set(JsonCpp_INCLUDE_DIR ${GenerateCLP_JsonCpp_INCLUDE_DIR})
+endif()
+
+set(GenerateCLP_JsonCpp_LIBRARY "@JsonCpp_LIBRARY@")
+if(NOT "${GenerateCLP_JsonCpp_LIBRARY}" STREQUAL "")
+  set(JsonCpp_LIBRARY ${GenerateCLP_JsonCpp_LIBRARY})
+endif()
+
+set(GenerateCLP_ParameterSerializer_DIR "@ParameterSerializer_DIR@")
+if(NOT "${GenerateCLP_ParameterSerializer_DIR}" STREQUAL "")
+  set(ParameterSerializer_DIR ${GenerateCLP_ParameterSerializer_DIR})
+endif()
 
 find_program(GENERATECLP_EXE
   NAMES GenerateCLPLauncher GenerateCLP

--- a/SlicerExecutionModelConfig.cmake.in
+++ b/SlicerExecutionModelConfig.cmake.in
@@ -146,9 +146,21 @@ endif()
 set(ModuleDescriptionParser_DIR ${SlicerExecutionModel_DIR}/ModuleDescriptionParser)
 set(GenerateCLP_DIR ${SlicerExecutionModel_DIR}/GenerateCLP)
 set(TCLAP_DIR ${SlicerExecutionModel_DIR}/tclap)
-set(JsonCpp_INCLUDE_DIR "@JsonCpp_INCLUDE_DIR@")
-set(JsonCpp_LIBRARY "@JsonCpp_LIBRARY@")
-set(ParameterSerializer_DIR "@ParameterSerializer_DIR@")
+
+set(SlicerExecutionModel_JsonCpp_INCLUDE_DIR "@JsonCpp_INCLUDE_DIR@")
+if(NOT "${SlicerExecutionModel_JsonCpp_INCLUDE_DIR}" STREQUAL "")
+  set(JsonCpp_INCLUDE_DIR ${SlicerExecutionModel_JsonCpp_INCLUDE_DIR})
+endif()
+
+set(SlicerExecutionModel_JsonCpp_LIBRARY "@JsonCpp_LIBRARY@")
+if(NOT "${SlicerExecutionModel_JsonCpp_LIBRARY}" STREQUAL "")
+  set(JsonCpp_LIBRARY ${SlicerExecutionModel_JsonCpp_LIBRARY})
+endif()
+
+set(SlicerExecutionModel_ParameterSerializer_DIR "@ParameterSerializer_DIR@")
+if(NOT "${SlicerExecutionModel_ParameterSerializer_DIR}" STREQUAL "")
+  set(ParameterSerializer_DIR ${SlicerExecutionModel_ParameterSerializer_DIR})
+endif()
 
 #
 # Find ModuleDescriptionParser, GenerateCLP and TCLAP so that the associated


### PR DESCRIPTION
This commit ensures project expected to find JsonCpp after finding
SlicerExecutionModel can do successfully even when SlicerExecutionModel
is built without ParameterSerializer support.

See https://github.com/Slicer/Slicer/issues/5080