### PR TITLE
BUG: Do not override ITK_DIR in CMake package configurations

### DIFF
--- a/GenerateCLP/GenerateCLP.cxx
+++ b/GenerateCLP/GenerateCLP.cxx
@@ -525,8 +525,12 @@ void GenerateDeSerialization( std::ostream & sout,
     | "    return EXIT_FAILURE;"
     | "    }"
     | "  Json::Value root;"
-    | "  Json::Reader reader;"
-    | "  reader.parse( fStream, root );"
+    | "  Json::CharReaderBuilder builder;"
+    | "  JSONCPP_STRING errs;"
+    | "  if (!parseFromStream(builder, fStream, &root, &errs)) {"
+    | "    std::cout << errs << std::endl;"
+    | "    return EXIT_FAILURE;"
+    | "  }"
     | "  const Json::Value & parameters = root[\"Parameters\"];";
 
   typedef std::vector<ModuleParameterGroup> ModuleParameterGroupsType;
@@ -593,8 +597,9 @@ void GenerateSerialization( std::ostream & sout,
     | "    std::cerr << \"Could not open file: \" << parametersSerializeArg.getValue() << \" for writing.\" << std::endl;"
     | "    return EXIT_FAILURE;"
     | "    }"
-    | "  Json::StyledStreamWriter writer;"
-    | "  writer.write( fStream, root );"
+    | "  Json::StreamWriterBuilder builder;"
+    | "  const std::unique_ptr<Json::StreamWriter> writer(builder.newStreamWriter());"
+    | "  writer->write( root, &fStream );"
     | "  fStream.close();"
     | "  }";
 }

--- a/GenerateCLP/GenerateCLPConfig.cmake.in
+++ b/GenerateCLP/GenerateCLPConfig.cmake.in
@@ -9,7 +9,9 @@ set(GenerateCLP_USE_JSONCPP "@GenerateCLP_USE_JSONCPP@")
 set(GenerateCLP_USE_SERIALIZER "@GenerateCLP_USE_SERIALIZER@")
 set(TCLAP_DIR "@TCLAP_DIR@")
 set(ModuleDescriptionParser_DIR "@ModuleDescriptionParser_DIR@")
-set(ITK_DIR "@ITK_DIR_CONFIG@")
+if (NOT DEFINED ITK_DIR)
+  set(ITK_DIR "@ITK_DIR_CONFIG@")
+endif()
 
 find_program(GENERATECLP_EXE
   NAMES GenerateCLPLauncher GenerateCLP

--- a/GenerateCLP/GenerateCLPInstallConfig.cmake.in
+++ b/GenerateCLP/GenerateCLPInstallConfig.cmake.in
@@ -18,5 +18,6 @@ set(GENERATECLP_EXE "${GENERATECLP_EXE}${__EXE_EXT}")
 get_filename_component(GENERATECLP_EXE "${GENERATECLP_EXE}" ABSOLUTE)
 set(TCLAP_DIR "@TCLAP_DIR@")
 set(ModuleDescriptionParser_DIR "@ModuleDescriptionParser_DIR@")
-set(ITK_DIR "@ITK_DIR@")
-
+if (NOT DEFINED ITK_DIR)
+  set(ITK_DIR "@ITK_DIR@")
+endif()

--- a/ModuleDescriptionParser/ModuleDescriptionParserConfig.cmake.in
+++ b/ModuleDescriptionParser/ModuleDescriptionParserConfig.cmake.in
@@ -9,7 +9,9 @@ set(ModuleDescriptionParser_USE_FILE
   "@ModuleDescriptionParser_USE_FILE_CONFIG@"
   )
 
-set(ITK_DIR "@ITK_DIR_CONFIG@")
+if (NOT DEFINED ITK_DIR)
+  set(ITK_DIR "@ITK_DIR_CONFIG@")
+endif()
 
 set(ModuleDescriptionParser_ITK_COMPONENTS "@ModuleDescriptionParser_ITK_COMPONENTS@")
 

--- a/ModuleDescriptionParser/ModuleDescriptionParserInstallConfig.cmake.in
+++ b/ModuleDescriptionParser/ModuleDescriptionParserInstallConfig.cmake.in
@@ -16,4 +16,6 @@ set(ModuleDescriptionParser_USE_FILE
   "${ModuleDescriptionParser_CONFIG_DIR}/UseModuleDescriptionParser.cmake"
   )
 
-set(ITK_DIR "@ITK_DIR@")
+if (NOT DEFINED ITK_DIR)
+  set(ITK_DIR "@ITK_DIR@")
+endif()


### PR DESCRIPTION
Enable a different ITK to build built against when building the CLI,
e.g. when cross-compiling.