### PR TITLE
COMP: Fix CDash submission switching drop method from `http` to `https`

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,7 +1,7 @@
 set(CTEST_PROJECT_NAME "SlicerExecutionModel")
 set(CTEST_NIGHTLY_START_TIME "3:00:00 UTC")
 
-set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_METHOD "https")
 set(CTEST_DROP_SITE "slicer.cdash.org")
 set(CTEST_DROP_LOCATION "/submit.php?project=SlicerExecutionModel")
 set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
This fixes the following error:

```
[...]
Submit files
   SubmitURL: http://slicer.cdash.org/submit.php?project=SlicerExecutionModel
   Upload file: /usr/src/SlicerExecutionModel-build/Testing/20250120-2048/Configure.xml to http://slicer.cdash.org/submit.php?project=SlicerExecutionModel&FileName=ca0c14e99f9c___itk-master_use_system_libraries-off___20250120-2048-Experimental___XML___Configure.xml&build=itk-master_use_system_libraries-off&site=ca0c14e99f9c&stamp=20250120-2048-Experimental&MD5=a49999bfa20478093b22e167865fae85 Size: 1243
   Submit failed, waiting 5 seconds...
   Retry submission: Attempt 1 of 3
[...]
```