### PR TITLE
COMP: Fix expat name mangling error

### DIFF
--- a/ModuleDescriptionParser/ModuleDescriptionParser.cxx
+++ b/ModuleDescriptionParser/ModuleDescriptionParser.cxx
@@ -16,12 +16,19 @@
 #include "ModuleDescription.h"
 #include "ModuleDescriptionUtilities.h"
 
+#include <itkConfigure.h>
+#if ITK_VERSION_MAJOR >= 6
+#  include <itk_expat.h> // ITK v6 and above <itk_expat.h> to redirect to system or itk mangled symbols as needed
+#else
+#  include <expat.h> // ITK v5 and below re-used the common <expat.h> for itk mangled symbols
+#endif
+
 #include <iostream>
 #include <string>
 #include <string.h>
 #include <vector>
 #include <stack>
-#include "expat.h"
+
 
 /*********************
  * Utility procedures for strings

--- a/test/Docker-ITK-master_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
+++ b/test/Docker-ITK-master_USE_SYSTEM_LIBRARIES-OFF/Dockerfile
@@ -15,7 +15,7 @@ RUN \
   #
   # Checkout
   #
-  git clone git://github.com/jcfr/ITK ITK && \
+  git clone https://github.com/jcfr/ITK.git ITK && \
   cd ITK && git reset --hard ${ITK_GIT_COMMIT} && \
   #
   # Configure

--- a/test/Docker/test-serializer.sh
+++ b/test/Docker/test-serializer.sh
@@ -7,7 +7,7 @@ set -ex
 
 # jsoncpp
 cd /usr/src
-git clone git://github.com/Slicer/jsoncpp.git
+git clone https://github.com/Slicer/jsoncpp.git
 mkdir jsoncpp-build && cd $_
 cmake -G Ninja \
   -DBUILD_TESTING:BOOL=OFF \
@@ -23,7 +23,7 @@ ninja install
 
 # ParameterSerializer
 cd /usr/src
-git clone git://github.com/Slicer/ParameterSerializer.git
+git clone https://github.com/Slicer/ParameterSerializer.git
 mkdir ParameterSerializer-build && cd $_
 cmake \
   -G Ninja \


### PR DESCRIPTION
ITK Version 6.0 provides more comprehensive name mangling for the Expat libraries.  One must include "itk_expat.h" instead of "expat.h" in order to get the mangled names from ITK that are needed to avoid undefined symbols during linkage.