### PR TITLE
ENH: Allow docker testing support scripts to work outside of docker

### DIFF
--- a/test/Docker/test-serializer.sh
+++ b/test/Docker/test-serializer.sh
@@ -5,10 +5,18 @@ set -ex
 # This is a script to build the project and run the test suite in the base
 # Docker container.
 
+SEM_ROOT_DIR=$(git rev-parse --show-toplevel)
+SRC_ROOT_DIR=$(dirname ${SEM_ROOT_DIR})
+
+if [ -z "${ITK_DIR}" ]; then
+  echo "WARNING:  Environmental variable ITK_DIR must be set to support building SlicerExecutionModel"
+fi
+
 # jsoncpp
-cd /usr/src
-git clone https://github.com/Slicer/jsoncpp.git
-mkdir jsoncpp-build && cd $_
+if [ ! -d ${SRC_ROOT_DIR}/jsoncpp ]; then
+  git clone https://github.com/Slicer/jsoncpp.git ${SRC_ROOT_DIR}/jsoncpp
+fi
+mkdir ${SRC_ROOT_DIR}/jsoncpp-build && cd $_
 cmake -G Ninja \
   -DBUILD_TESTING:BOOL=OFF \
   -DJSONCPP_WITH_TESTS:BOOL=OFF \
@@ -18,29 +26,34 @@ cmake -G Ninja \
   -DJSONCPP_WITH_CMAKE_PACKAGE:BOOL=ON \
   -DBUILD_SHARED_LIBS:BOOL=ON \
   -DBUILD_STATIC_LIBS:BOOL=OFF \
-  ../jsoncpp
-ninja install
+  -B ${SRC_ROOT_DIR}/jsoncpp-build \
+  -S ../jsoncpp
+ninja -C ${SRC_ROOT_DIR}/jsoncpp-build install
 
 # ParameterSerializer
-cd /usr/src
-git clone https://github.com/Slicer/ParameterSerializer.git
-mkdir ParameterSerializer-build && cd $_
+cd ${SRC_ROOT_DIR}
+if [ ! -d ${SRC_ROOT_DIR}/ParameterSerializer ]; then
+  git clone https://github.com/Slicer/ParameterSerializer.git ${SRC_ROOT_DIR}/ParameterSerializer
+fi
+mkdir ${SRC_ROOT_DIR}/ParameterSerializer-build && cd $_
 cmake \
   -G Ninja \
   -DBUILD_TESTING:BOOL=OFF \
   -DCMAKE_BUILD_TYPE:STRING=Release \
-  /usr/src/ParameterSerializer
-ninja
+  -B ${SRC_ROOT_DIR}/ParameterSerializer-build \
+  -S ${SRC_ROOT_DIR}/ParameterSerializer
+ninja -C ${SRC_ROOT_DIR}/ParameterSerializer-build
 
 # SlicerExecutionModel
-mkdir -p /usr/src/SlicerExecutionModel-build && cd $_
+mkdir -p ${SRC_ROOT_DIR}/SlicerExecutionModel-build && cd $_
 BUILDNAME=sem_use_serializer-on_$1
 cmake \
   -G Ninja \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILDNAME:STRING=$BUILDNAME \
-  -DParameterSerializer_DIR:PATH=/usr/src/ParameterSerializer-build \
+  -DParameterSerializer_DIR:PATH=${SRC_ROOT_DIR}/ParameterSerializer-build \
   -DSlicerExecutionModel_USE_SERIALIZER:BOOL=ON \
   -DSlicerExecutionModel_USE_JSONCPP:BOOL=ON \
-    /usr/src/SlicerExecutionModel
+  -B ${SRC_ROOT_DIR}/SlicerExecutionModel-build \
+  -S ${SRC_ROOT_DIR}/SlicerExecutionModel
 ctest -VV -D Experimental

--- a/test/Docker/test.sh
+++ b/test/Docker/test.sh
@@ -5,11 +5,19 @@ set -ex
 # This is a script to build the project and run the test suite in the base
 # Docker container.
 
+SEM_ROOT_DIR=$(git rev-parse --show-toplevel)
+SRC_ROOT_DIR=$(dirname ${SEM_ROOT_DIR})
+
+if [ -z "${ITK_DIR}" ]; then
+  echo "WARNING:  Environmental variable ITK_DIR must be set to support building SlicerExecutionModel"
+fi
+
 # SlicerExecutionModel
-mkdir -p /usr/src/SlicerExecutionModel-build && cd $_
+mkdir -p ${SRC_ROOT_DIR}/SlicerExecutionModel-build && cd $_
 cmake \
   -G Ninja \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILDNAME:STRING=$1 \
-    /usr/src/SlicerExecutionModel
+  -B ${SRC_ROOT_DIR}/SlicerExecutionModel-build \
+  -S ${SEM_ROOT_DIR}
 ctest -VV -D Experimental


### PR DESCRIPTION
Make the testing scripts more generic so that they can be run
in a standard environment to improve debugging convenience.

Replace hard-coded docker paths with auto-generated relative paths.
Explicitly specify build and source directories for easier tracking.
